### PR TITLE
Disable OpenAI API request storage

### DIFF
--- a/src/js/services/api/requestClient.js
+++ b/src/js/services/api/requestClient.js
@@ -51,7 +51,7 @@ export function buildRequestBody({
       verbosity: verbosity || DEFAULT_VERBOSITY,
     },
     input: serializeMessagesForRequest(inputMessages),
-    store: true,
+    store: false,
   };
   if (serviceKey !== 'xai' && !isLocalService) {
     payload.include = [...DEFAULT_INCLUDE_FIELDS];


### PR DESCRIPTION
## Summary
- Set `store=false` on Responses API requests to prevent conversations from being logged/stored on OpenAI's side

## Test plan
- [x] Verify API requests still work correctly across all providers

🤖 Generated with [Claude Code](https://claude.com/claude-code)