### PR TITLE
Add OpenAI shell tool with reasoning panel output

### DIFF
--- a/src/css/components/ui/tool-settings.css
+++ b/src/css/components/ui/tool-settings.css
@@ -398,6 +398,11 @@
   gap: 12px;
 }
 
+.mcp-server-description {
+  font-size: 0.8rem;
+  margin-top: 4px;
+}
+
 /* MCP Add Form Styling */
 
 .mcp-add-form {

--- a/src/js/components/messages.js
+++ b/src/js/components/messages.js
@@ -134,12 +134,13 @@ window.appendMessage = function(sender, message, role, skipHistory = false) {
       return originalSelector.call(document, selector);
     };
 
-    if (typeof window.renderWordmarkLogo === "function") {
-      window.renderWordmarkLogo();
+    try {
+      if (typeof window.renderWordmarkLogo === "function") {
+        window.renderWordmarkLogo();
+      }
+    } finally {
+      document.querySelector = originalSelector;
     }
-
-    // Restore original querySelector
-    document.querySelector = originalSelector;
   } else {
     // Fallback for other sender types
     senderElement.textContent = sender;

--- a/src/js/components/ui/chatMessages.js
+++ b/src/js/components/ui/chatMessages.js
@@ -13,11 +13,13 @@ function renderAssistantIcon(senderElement) {
     return originalSelector.call(document, selector);
   };
 
-  if (typeof window.renderWordmarkLogo === 'function') {
-    window.renderWordmarkLogo();
+  try {
+    if (typeof window.renderWordmarkLogo === 'function') {
+      window.renderWordmarkLogo();
+    }
+  } finally {
+    document.querySelector = originalSelector;
   }
-
-  document.querySelector = originalSelector;
 }
 
 window.appendMessage = function(sender, content, type, skipHistory = false) {

--- a/src/js/services/api/requestClient.js
+++ b/src/js/services/api/requestClient.js
@@ -208,7 +208,13 @@ export async function runTurn({
   let aggregateText = '';
   let aggregateReasoning = '';
 
+  const MAX_TOOL_CALL_ITERATIONS = 20;
+  let toolCallIteration = 0;
+
   while (true) {
+    if (++toolCallIteration > MAX_TOOL_CALL_ITERATIONS) {
+      throw new Error(`Tool call loop exceeded maximum of ${MAX_TOOL_CALL_ITERATIONS} iterations`);
+    }
     const body = buildRequestBody({
       inputMessages: workingMessages,
       instructions: typeof instructions === 'string' && instructions.trim() ? instructions : undefined,

--- a/src/js/services/api/toolManager.js
+++ b/src/js/services/api/toolManager.js
@@ -109,6 +109,20 @@ const STATIC_TOOLS = [
     },
   },
   {
+    key: 'builtin:shell',
+    type: 'builtin',
+    displayName: 'Shell',
+    description: 'Allow the assistant to run shell commands in a sandboxed container environment.',
+    defaultEnabled: false,
+    onlyServices: ['openai'],
+    definition: {
+      type: 'shell',
+      environment: {
+        type: 'container_auto',
+      },
+    },
+  },
+  {
     key: 'builtin:file_search',
     type: 'builtin',
     displayName: 'File Search',
@@ -319,6 +333,7 @@ const SERVER_MANAGED_TOOL_TYPES = new Set([
   'web_search',
   'x_search',
   'code_interpreter',
+  'shell',
   'image_generation',
   'file_search',
 ]);
@@ -570,7 +585,15 @@ export function getEnabledToolDefinitions(serviceKey = getActiveServiceKey(), mo
       return;
     }
 
+    // Shell and code_interpreter cannot be used together; shell wins if both enabled
     if (tool.key === 'builtin:code_interpreter') {
+      const shellEnabled = getToolPreference('builtin:shell', false);
+      if (shellEnabled && serviceKey === 'openai') {
+        if (window.VERBOSE_LOGGING) {
+          console.info('Skipping code_interpreter because shell tool is enabled.');
+        }
+        return;
+      }
       if (serviceKey === 'xai') {
         defs.push({
           type: 'code_interpreter',

--- a/src/js/services/history/render.js
+++ b/src/js/services/history/render.js
@@ -132,8 +132,11 @@ window.renderConversationMessages = function(convo, imageCache) {
       return originalSelector.call(document, selector);
     };
 
-    window.renderWordmarkLogo?.();
-    document.querySelector = originalSelector;
+    try {
+      window.renderWordmarkLogo?.();
+    } finally {
+      document.querySelector = originalSelector;
+    }
 
     messageElement.appendChild(sender);
 

--- a/src/js/services/mcpServers.js
+++ b/src/js/services/mcpServers.js
@@ -87,26 +87,47 @@ function renderMCPServersList() {
     return;
   }
 
-  container.innerHTML = servers.map(server => `
-    <div class="mcp-server-item" data-server-label="${server.server_label}">
-      <div class="mcp-server-info">
-        <strong>${server.displayName}</strong>
-        <div class="mcp-server-details">
-          <code>${server.server_url}</code>
-          ${server.description ? `<div style="font-size: 0.8rem; margin-top: 4px;">${server.description}</div>` : ""}
-        </div>
-      </div>
-      <button type="button" class="mcp-server-remove" data-server-label="${server.server_label}" title="Remove Server">
-        <svg xmlns="http://www.w3.org/2000/svg" width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round">
-          <use href="src/assets/icons.svg#trash"></use>
-        </svg>
-      </button>
-    </div>
-  `).join("");
+  container.innerHTML = "";
 
-  // Add event listeners for remove buttons
-  container.querySelectorAll(".mcp-server-remove").forEach(button => {
-    button.addEventListener("click", handleRemoveServer);
+  servers.forEach(server => {
+    const item = document.createElement("div");
+    item.className = "mcp-server-item";
+    item.dataset.serverLabel = server.server_label;
+
+    const info = document.createElement("div");
+    info.className = "mcp-server-info";
+
+    const name = document.createElement("strong");
+    name.textContent = server.displayName;
+    info.appendChild(name);
+
+    const details = document.createElement("div");
+    details.className = "mcp-server-details";
+
+    const url = document.createElement("code");
+    url.textContent = server.server_url;
+    details.appendChild(url);
+
+    if (server.description) {
+      const desc = document.createElement("div");
+      desc.className = "mcp-server-description";
+      desc.textContent = server.description;
+      details.appendChild(desc);
+    }
+
+    info.appendChild(details);
+    item.appendChild(info);
+
+    const removeBtn = document.createElement("button");
+    removeBtn.type = "button";
+    removeBtn.className = "mcp-server-remove";
+    removeBtn.dataset.serverLabel = server.server_label;
+    removeBtn.title = "Remove Server";
+    removeBtn.innerHTML = window.icon("trash", { width: 16, height: 16 });
+    removeBtn.addEventListener("click", handleRemoveServer);
+    item.appendChild(removeBtn);
+
+    container.appendChild(item);
   });
 }
 

--- a/src/js/services/streaming/eventProcessor.js
+++ b/src/js/services/streaming/eventProcessor.js
@@ -275,7 +275,24 @@ export function createStreamingEventProcessor(runtime) {
       const itype = item?.type ? String(item.type).toLowerCase() : '';
       const itemId = item?.id || '';
 
-      if ((itype.includes('tool') || itype.includes('function')) && !itype.includes('output')) {
+      if (itype === 'shell_call') {
+        toolExecutions.set(itemId, {
+          name: 'shell',
+          status: 'started',
+          startTime: Date.now(),
+        });
+        const cmds = item?.action?.commands;
+        if (Array.isArray(cmds) && cmds.length > 0) {
+          runtime.appendReasoningLine('**🖥️ shell**:');
+          cmds.forEach(c => {
+            runtime.appendReasoningLine(`  \`$ ${c.length > 120 ? c.slice(0, 120) + '…' : c}\``);
+          });
+          runtime.appendReasoningLine('  ⏳ _executing…_');
+        } else {
+          runtime.appendReasoningLine('**🖥️ shell**:');
+          runtime.appendReasoningLine('  ⏳ _executing…_');
+        }
+      } else if ((itype.includes('tool') || itype.includes('function')) && !itype.includes('output')) {
         const name = item?.name || item?.tool_name || item?.function?.name || 'tool';
         toolExecutions.set(itemId, {
           name,
@@ -291,7 +308,87 @@ export function createStreamingEventProcessor(runtime) {
       const itype = item?.type ? String(item.type).toLowerCase() : '';
       const itemId = item?.id || '';
 
-      if ((itype.includes('tool') || itype.includes('function')) && !itype.includes('output')) {
+      if (itype === 'shell_call') {
+        const exec = toolExecutions.get(itemId);
+        if (exec) {
+          const duration = Date.now() - exec.startTime;
+          runtime.appendReasoningLine(`  ✔️ _completed in ${duration}ms_`);
+          runtime.appendReasoningLine('');
+          toolExecutions.delete(itemId);
+        }
+      } else if (itype === 'shell_call_output') {
+        const outputList = Array.isArray(item?.output) ? item.output : [];
+        for (const out of outputList) {
+          if (!out || typeof out !== 'object') continue;
+          const stdout = typeof out.stdout === 'string' ? out.stdout.trim() : '';
+          const stderr = typeof out.stderr === 'string' ? out.stderr.trim() : '';
+          const outcome = out.outcome || {};
+          if (stdout) {
+            const lines = stdout.split('\n');
+            const preview = lines.length > 15
+              ? [...lines.slice(0, 15), `… (${lines.length - 15} more lines)`]
+              : lines;
+            runtime.appendReasoningLine('  ```');
+            preview.forEach(line => runtime.appendReasoningLine(`  ${line}`));
+            runtime.appendReasoningLine('  ```');
+          }
+          if (stderr) {
+            const lines = stderr.split('\n');
+            const preview = lines.length > 10
+              ? [...lines.slice(0, 10), `… (${lines.length - 10} more lines)`]
+              : lines;
+            runtime.appendReasoningLine('  ⚠️ stderr:');
+            runtime.appendReasoningLine('  ```');
+            preview.forEach(line => runtime.appendReasoningLine(`  ${line}`));
+            runtime.appendReasoningLine('  ```');
+          }
+          if (outcome.type === 'exit' && typeof outcome.exit_code === 'number' && outcome.exit_code !== 0) {
+            runtime.appendReasoningLine(`  ❌ _exit code: ${outcome.exit_code}_`);
+          }
+          if (outcome.type === 'timeout') {
+            runtime.appendReasoningLine('  ⏳ _timed out_');
+          }
+        }
+        runtime.appendReasoningLine('');
+      } else if (itype.includes('code_interpreter')) {
+        const ciRoot = item?.code_interpreter_call || item;
+        const ciOutputs = ciRoot?.results || ciRoot?.outputs || ciRoot?.output || [];
+        const outputArr = Array.isArray(ciOutputs) ? ciOutputs : [];
+        const topLogs = typeof ciRoot?.logs === 'string' ? ciRoot.logs.trim() : '';
+        if (topLogs) {
+          const lines = topLogs.split('\n');
+          const preview = lines.length > 20
+            ? [...lines.slice(0, 20), `… (${lines.length - 20} more lines)`]
+            : lines;
+          runtime.appendReasoningLine('  📄 output:');
+          runtime.appendReasoningLine('  ```');
+          preview.forEach(line => runtime.appendReasoningLine(`  ${line}`));
+          runtime.appendReasoningLine('  ```');
+        }
+        for (const out of outputArr) {
+          if (!out || typeof out !== 'object') continue;
+          const outType = typeof out.type === 'string' ? out.type.toLowerCase() : '';
+          if (outType.includes('log') || outType === 'stderr') {
+            const raw = out.logs ?? out.text ?? out.content ?? '';
+            const text = Array.isArray(raw) ? raw.join('\n') : (raw ? String(raw) : '');
+            if (text && text.trim()) {
+              const lines = text.trim().split('\n');
+              const preview = lines.length > 20
+                ? [...lines.slice(0, 20), `… (${lines.length - 20} more lines)`]
+                : lines;
+              runtime.appendReasoningLine('  📄 output:');
+              runtime.appendReasoningLine('  ```');
+              preview.forEach(line => runtime.appendReasoningLine(`  ${line}`));
+              runtime.appendReasoningLine('  ```');
+            }
+          } else if (outType.includes('image') || outType.includes('file')) {
+            const filename = out.filename || out.name || out.file_id || out.fileId || '';
+            if (filename) {
+              runtime.appendReasoningLine(`  📄 _${filename}_`);
+            }
+          }
+        }
+      } else if ((itype.includes('tool') || itype.includes('function')) && !itype.includes('output')) {
         const exec = toolExecutions.get(itemId);
         if (exec) {
           const duration = Date.now() - exec.startTime;
@@ -479,11 +576,10 @@ export function createStreamingEventProcessor(runtime) {
     }
     case 'response.code_interpreter_call.in_progress': {
       runtime.appendReasoningLine('**💻 code_interpreter**:');
-      runtime.appendReasoningLine('  ⏳ _preparing…_');
       break;
     }
     case 'response.code_interpreter_call.interpreting': {
-      runtime.updateLastReasoningLine('  ▶️ _executing…_');
+      runtime.appendReasoningLine('  ▶️ _executing…_');
       break;
     }
     case 'response.code_interpreter_call.completed': {
@@ -513,19 +609,10 @@ export function createStreamingEventProcessor(runtime) {
         ? payload.code
         : (payload.code ? JSON.stringify(payload.code) : bufferGet(codeBuffers, itemId));
       if (code && code.length > 0) {
-        const preview = code.length > 200 ? `${code.slice(0, 200)}…` : code;
-        const lines = preview.split('\n');
-        if (lines.length > 5) {
-          runtime.appendReasoningLine(`  code: (${lines.length} lines)`);
-          lines.slice(0, 5).forEach(line => {
-            runtime.appendReasoningLine(`    ${line}`);
-          });
-          if (lines.length > 5) {
-            runtime.appendReasoningLine(`    ... (${lines.length - 5} more lines)`);
-          }
-        } else {
-          runtime.appendReasoningLine(`  code: ${preview}`);
-        }
+        const lines = code.split('\n');
+        runtime.appendReasoningLine('  ```python');
+        lines.forEach(line => runtime.appendReasoningLine(`  ${line}`));
+        runtime.appendReasoningLine('  ```');
       }
       activeCodeStreams.delete(itemId);
       break;


### PR DESCRIPTION
## Summary
- Add OpenAI shell tool (`container_auto` environment) to the tool catalog
- Shell and code_interpreter are mutually exclusive; shell takes priority when both enabled
- Display shell commands, stdout, stderr, and exit codes in the reasoning panel in real-time
- Display code_interpreter output/logs in the reasoning panel
- Fix code_interpreter: show full code in fenced blocks (was truncated to 200 chars/5 lines)
- Fix code_interpreter: prevent "executing" status from overwriting code block closing marks
- Includes security fixes from the `fixes` branch

## Test plan
- [x] Enable shell tool in settings, verify it appears and can be toggled
- [x] Send a prompt that triggers shell usage, verify commands and output appear in reasoning panel
- [x] Enable both shell and code_interpreter, verify only shell is sent to the API
- [x] Disable shell, enable code_interpreter, verify code_interpreter works with full code display
- [x] Verify code_interpreter "executing" status doesn't corrupt code blocks in reasoning

🤖 Generated with [Claude Code](https://claude.com/claude-code)