### PR TITLE
Add missing TTS voices and header toggle badge

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,7 +30,7 @@
   - Tool calling: built-in Open-Meteo weather helper, provider web + X search, Code Interpreter, optional image generation and file search, plus your own MCP servers — see [Tool Calling](docs/tool-calling.md)
   - Streaming & reasoning: dedicated reasoning panel, rich tool timelines, inline code previews, and automatic image capture — more in [Streaming](docs/streaming.md)
   - UX: themes, responsive layout, syntax highlighting, markdown, image gallery — design notes in [UI & UX](docs/ui-and-ux.md)
-  - TTS: multiple voices, optional autoplay, simple controls
+  - TTS: 13 voices (including cedar and marin), optional autoplay, per-message controls, audio cached locally
   - Local‑only storage: conversations, images, audio via IndexedDB; keys kept in the browser — details in [Storage](docs/storage.md)
   - Optional memory: local, FIFO‑limited memories appended to the system prompt — behavior and API in [Memory](docs/memory.md)
 

--- a/docs/overview.md
+++ b/docs/overview.md
@@ -15,7 +15,7 @@ Key Features
 - Themes and responsive UI
  - Header shortcuts and indicators:
    - Click the logo (About), model name (Model), or personality line (Personality) to open those Settings tabs.
-   - Feature badges beneath the prompt show Location/Memory/Tools status; tap the dot to toggle, click the label to open settings.
+   - Feature badges beneath the prompt show Location/Memory/Tools/TTS status; tap the dot to toggle, click the label to open settings.
    - Hover the model name to see a provider tooltip (OpenAI, xAI, LM Studio, or Ollama).
 
 How It Starts

--- a/docs/ui-and-ux.md
+++ b/docs/ui-and-ux.md
@@ -37,8 +37,10 @@ Uploads
 
 TTS
 
-- Toggle + settings in the Settings panel. Voices are categorized (neutral/male/female per current `tts.js`).
-- When enabled, the app can autoplay newly generated assistant messages. Audio is cached in IndexedDB.
+- Toggle via the header TTS badge or in Settings → TTS. 13 voices organized by gender (neutral: fable; male: ash, ballad, cedar, echo, onyx, verse; female: alloy, coral, marin, nova, sage, shimmer). Cedar and marin are recommended by OpenAI for best quality.
+- Optional voice instructions let you customize speech style (e.g. "Speak cheerfully"). Falls back to the active personality prompt if set.
+- Autoplay mode queues and plays new assistant messages sequentially. Per-message controls provide play/pause, stop, and download (WAV).
+- Audio is cached in IndexedDB (last 15 files kept). Uses the `gpt-4o-mini-tts` model via the OpenAI API.
 
 Mobile
 

--- a/src/js/components/settings.js
+++ b/src/js/components/settings.js
@@ -260,6 +260,7 @@ window.updateFeatureStatus = function() {
     memory: (() => { try { return Boolean(window.getMemoryConfig && window.getMemoryConfig().enabled); } catch { return false; } })(),
     tools: Boolean(window.config && window.config.enableFunctionCalling !== false),
     data: Boolean(typeof window.getDataSettingsEnabled === "function" ? window.getDataSettingsEnabled() : (localStorage.getItem("dataSettingsEnabled") !== "false")),
+    tts: Boolean(window.ttsConfig?.enabled),
   };
 
   // Rebuild to bind handlers
@@ -336,6 +337,14 @@ window.updateFeatureStatus = function() {
         }
         break;
       }
+      case "tts": {
+        const toggle = document.getElementById("tts-toggle");
+        if (toggle) {
+          toggle.checked = !isOn;
+          toggle.dispatchEvent(new Event("change", { bubbles: true }));
+        }
+        break;
+      }
       }
       setTimeout(() => window.updateFeatureStatus(), 50);
     };
@@ -361,6 +370,7 @@ window.updateFeatureStatus = function() {
   el.appendChild(makeBadge("Memory", "memory", state.memory, "tab-memory"));
   el.appendChild(makeBadge("Tools", "tools", state.tools, "tab-tools"));
   el.appendChild(makeBadge("Data", "data", state.data, "tab-data"));
+  el.appendChild(makeBadge("TTS", "tts", state.tts, "tab-tts"));
 };
 
 /**

--- a/src/js/init/eventListeners/tts.js
+++ b/src/js/init/eventListeners/tts.js
@@ -18,6 +18,9 @@ export function setupTtsEventListeners() {
           window.stopTtsAudio();
         }
       }
+      if (typeof window.updateFeatureStatus === 'function') {
+        window.updateFeatureStatus();
+      }
     });
   }
 

--- a/src/js/services/tts/config.js
+++ b/src/js/services/tts/config.js
@@ -29,6 +29,7 @@ window.availableTtsVoices = {
   male: [
     { id: 'ash', name: 'Ash', gender: 'Male' },
     { id: 'ballad', name: 'Ballad', gender: 'Male' },
+    { id: 'cedar', name: 'Cedar', gender: 'Male' },
     { id: 'echo', name: 'Echo', gender: 'Male' },
     { id: 'onyx', name: 'Onyx', gender: 'Male' },
     { id: 'verse', name: 'Verse', gender: 'Male' },
@@ -36,6 +37,7 @@ window.availableTtsVoices = {
   female: [
     { id: 'alloy', name: 'Alloy', gender: 'Female' },
     { id: 'coral', name: 'Coral', gender: 'Female' },
+    { id: 'marin', name: 'Marin', gender: 'Female' },
     { id: 'nova', name: 'Nova', gender: 'Female' },
     { id: 'sage', name: 'Sage', gender: 'Female' },
     { id: 'shimmer', name: 'Shimmer', gender: 'Female' },


### PR DESCRIPTION
## Summary
- Added cedar (male) and marin (female) voices to TTS config, bringing the total to 13 — all current OpenAI TTS voices
- Added TTS badge to the header feature-status row, matching the existing Location/Memory/Tools/Data pattern
- Updated docs (README, overview, ui-and-ux) with voice list and new header control

## Test plan
- [x] Verify cedar and marin appear in the TTS voice selector dropdown
- [x] Confirm TTS header badge toggles TTS on/off and stays in sync with the settings panel checkbox
- [x] Click the TTS badge label to confirm it opens the TTS settings tab
- [x] Test voice playback with cedar and marin voices

🤖 Generated with [Claude Code](https://claude.com/claude-code)