### PR TITLE
Add xAI TTS provider support

### DIFF
--- a/docs/ui-and-ux.md
+++ b/docs/ui-and-ux.md
@@ -37,10 +37,11 @@ Uploads
 
 TTS
 
-- Toggle via the header TTS badge or in Settings → TTS. 13 voices organized by gender (neutral: fable; male: ash, ballad, cedar, echo, onyx, verse; female: alloy, coral, marin, nova, sage, shimmer). Cedar and marin are recommended by OpenAI for best quality.
-- Optional voice instructions let you customize speech style (e.g. "Speak cheerfully"). Falls back to the active personality prompt if set.
+- Toggle via the header TTS badge or in Settings → TTS. A provider selector lets you choose between OpenAI and xAI (Grok) for speech generation.
+- **OpenAI**: 13 voices organized by gender (neutral: fable; male: ash, ballad, cedar, echo, onyx, verse; female: alloy, coral, marin, nova, sage, shimmer). Uses the `gpt-4o-mini-tts` model. Optional voice instructions let you customize speech style (e.g. "Speak cheerfully"); falls back to the active personality prompt if set.
+- **xAI**: 5 voices (male: leo, rex, sal; female: ara, eve). Uses the xAI TTS API at `api.x.ai/v1/tts` with automatic language detection. Voice instructions are not supported.
 - Autoplay mode queues and plays new assistant messages sequentially. Per-message controls provide play/pause, stop, and download (WAV).
-- Audio is cached in IndexedDB (last 15 files kept). Uses the `gpt-4o-mini-tts` model via the OpenAI API.
+- Audio is cached in IndexedDB (last 15 files kept). The voice selector updates dynamically when switching providers.
 
 Mobile
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "wordmark",
-  "version": "1.3.0",
+  "version": "1.4.0",
   "description": "Client-side AI assistant for the OpenAI Responses API and local LM Studio servers.",
   "main": "index.html",
   "type": "module",

--- a/src/config/config.js
+++ b/src/config/config.js
@@ -18,7 +18,7 @@ window.MCP_ASSUME_ONLINE = true;
 // DO NOT hardcode actual API keys here
 
 // Application version
-window.APP_VERSION = '1.3.0';
+window.APP_VERSION = '1.4.0';
 
 // GitHub repository URL
 window.GITHUB_URL = 'https://github.com/h1ddenpr0cess20/Wordmark';

--- a/src/html/panels/settings/tts.html
+++ b/src/html/panels/settings/tts.html
@@ -19,6 +19,15 @@
   </div>
 
   <div class="setting-item">
+    <label for="tts-provider-selector">TTS Provider</label>
+    <select id="tts-provider-selector">
+      <option value="openai">OpenAI</option>
+      <option value="xai">xAI (Grok)</option>
+    </select>
+    <p class="info-text">Select which service to use for speech generation</p>
+  </div>
+
+  <div class="setting-item">
     <label for="tts-voice-selector">TTS Voice</label>
     <select id="tts-voice-selector">
       <!-- Voice options will be populated dynamically -->

--- a/src/js/init/dom.js
+++ b/src/js/init/dom.js
@@ -38,6 +38,7 @@ function initializeDOMReferences() {
   // TTS elements
   window.ttsToggle = document.getElementById("tts-toggle");
   window.ttsAutoplayToggle = document.getElementById("tts-autoplay-toggle");
+  window.ttsProviderSelector = document.getElementById("tts-provider-selector");
   window.ttsVoiceSelector = document.getElementById("tts-voice-selector");
   window.ttsInstructionsInput = document.getElementById("tts-instructions");
   window.testTtsButton = document.getElementById("test-tts");

--- a/src/js/init/eventListeners/tts.js
+++ b/src/js/init/eventListeners/tts.js
@@ -37,9 +37,24 @@ export function setupTtsEventListeners() {
     });
   }
 
+  if (window.ttsProviderSelector) {
+    window.ttsProviderSelector.addEventListener('change', (event) => {
+      window.ttsConfig = window.ttsConfig || { enabled: false, provider: 'openai', voice: 'ash', instructions: '', autoplay: true };
+      window.ttsConfig.provider = event.target.value;
+      if (typeof window.populateTtsVoiceSelector === 'function') {
+        window.populateTtsVoiceSelector();
+      }
+      // xAI TTS doesn't support voice instructions
+      const instructionsItem = window.ttsInstructionsInput?.closest('.setting-item');
+      if (instructionsItem) {
+        instructionsItem.style.display = event.target.value === 'xai' ? 'none' : '';
+      }
+    });
+  }
+
   if (window.ttsVoiceSelector) {
     window.ttsVoiceSelector.addEventListener('change', (event) => {
-      window.ttsConfig = window.ttsConfig || { enabled: false, voice: 'ash', instructions: '', autoplay: true };
+      window.ttsConfig = window.ttsConfig || { enabled: false, provider: 'openai', voice: 'ash', instructions: '', autoplay: true };
       window.ttsConfig.voice = event.target.value;
     });
   }
@@ -59,8 +74,11 @@ export function setupTtsEventListeners() {
         return;
       }
 
-      const openaiApiKey = window.config.services.openai?.apiKey;
-      if (!openaiApiKey) {
+      const provider = window.ttsConfig.provider || 'openai';
+      const apiKey = provider === 'xai'
+        ? window.config.services.xai?.apiKey
+        : window.config.services.openai?.apiKey;
+      if (!apiKey) {
         return;
       }
 

--- a/src/js/init/globals.js
+++ b/src/js/init/globals.js
@@ -62,6 +62,7 @@ window.setNoPromptButton = null;
 // TTS-related references
 window.ttsToggle = null;
 window.ttsAutoplayToggle = null;
+window.ttsProviderSelector = null;
 window.ttsVoiceSelector = null;
 window.ttsInstructionsInput = null;
 window.testTtsButton = null;

--- a/src/js/init/initialization.js
+++ b/src/js/init/initialization.js
@@ -241,6 +241,11 @@ async function initialize() {
     // Initialize services and models
     initializeServicesAndModels();
 
+    // Initialize TTS voice selector and provider state
+    if (typeof window.initializeTts === "function") {
+      window.initializeTts();
+    }
+
     // Initialize mobile keyboard handling
     window.initializeMobileKeyboardHandling();
     if (window.VERBOSE_LOGGING) {

--- a/src/js/init/ttsInitialization.js
+++ b/src/js/init/ttsInitialization.js
@@ -6,6 +6,13 @@
  * Initialize TTS functionality
  */
 function initializeTts() {
+  if (!window.ttsConfig) return;
+
+  // Initialize TTS provider selector
+  if (window.ttsProviderSelector) {
+    window.ttsProviderSelector.value = window.ttsConfig.provider || 'openai';
+  }
+
   // Populate TTS voice selector
   populateTtsVoiceSelector();
 
@@ -22,6 +29,11 @@ function initializeTts() {
   // Initialize TTS instructions
   if (window.ttsInstructionsInput) {
     window.ttsInstructionsInput.value = window.ttsConfig.instructions || "";
+    // xAI TTS doesn't support voice instructions
+    const instructionsItem = window.ttsInstructionsInput.closest('.setting-item');
+    if (instructionsItem) {
+      instructionsItem.style.display = (window.ttsConfig.provider || 'openai') === 'xai' ? 'none' : '';
+    }
   }
 
   // Share references with TTS service
@@ -29,6 +41,7 @@ function initializeTts() {
     window.initTtsReferences({
       ttsToggle: window.ttsToggle,
       ttsAutoplayToggle: window.ttsAutoplayToggle,
+      ttsProviderSelector: window.ttsProviderSelector,
       ttsVoiceSelector: window.ttsVoiceSelector,
       ttsInstructionsInput: window.ttsInstructionsInput,
       personalityInput: window.personalityInput,
@@ -43,53 +56,35 @@ function initializeTts() {
  * Populate the TTS voice selector with available voices
  */
 function populateTtsVoiceSelector() {
-  if (window.ttsVoiceSelector && window.availableTtsVoices) {
-    // Clear existing options
+  if (window.ttsVoiceSelector && window.availableTtsVoices && window.ttsConfig) {
     window.ttsVoiceSelector.innerHTML = "";
 
-    // Add categorized voices with optgroups
-    const voices = window.availableTtsVoices;
+    const provider = window.ttsConfig.provider || 'openai';
+    const voices = window.availableTtsVoices[provider];
+    if (!voices) return;
 
-    // Add Neutral voices
-    if (voices.neutral && voices.neutral.length > 0) {
-      const neutralGroup = document.createElement("optgroup");
-      neutralGroup.label = "Neutral";
-      voices.neutral.forEach(voice => {
-        const option = document.createElement("option");
-        option.value = voice.id;
-        option.textContent = voice.name;
-        neutralGroup.appendChild(option);
-      });
-      window.ttsVoiceSelector.appendChild(neutralGroup);
+    const categories = ['neutral', 'male', 'female'];
+    const labels = { neutral: 'Neutral', male: 'Male', female: 'Female' };
+
+    for (const category of categories) {
+      if (voices[category] && voices[category].length > 0) {
+        const group = document.createElement("optgroup");
+        group.label = labels[category];
+        voices[category].forEach(voice => {
+          const option = document.createElement("option");
+          option.value = voice.id;
+          option.textContent = voice.name;
+          group.appendChild(option);
+        });
+        window.ttsVoiceSelector.appendChild(group);
+      }
     }
 
-    // Add Male voices
-    if (voices.male && voices.male.length > 0) {
-      const maleGroup = document.createElement("optgroup");
-      maleGroup.label = "Male";
-      voices.male.forEach(voice => {
-        const option = document.createElement("option");
-        option.value = voice.id;
-        option.textContent = voice.name;
-        maleGroup.appendChild(option);
-      });
-      window.ttsVoiceSelector.appendChild(maleGroup);
+    // If current voice isn't in the new provider's list, select the first available
+    const allVoiceIds = categories.flatMap(c => (voices[c] || []).map(v => v.id));
+    if (!allVoiceIds.includes(window.ttsConfig.voice)) {
+      window.ttsConfig.voice = allVoiceIds[0] || '';
     }
-
-    // Add Female voices
-    if (voices.female && voices.female.length > 0) {
-      const femaleGroup = document.createElement("optgroup");
-      femaleGroup.label = "Female";
-      voices.female.forEach(voice => {
-        const option = document.createElement("option");
-        option.value = voice.id;
-        option.textContent = voice.name;
-        femaleGroup.appendChild(option);
-      });
-      window.ttsVoiceSelector.appendChild(femaleGroup);
-    }
-
-    // Set default voice
     window.ttsVoiceSelector.value = window.ttsConfig.voice;
   }
 }

--- a/src/js/services/tts/api.js
+++ b/src/js/services/tts/api.js
@@ -4,59 +4,106 @@ window.generateSpeech = async function(text) {
   }
 
   try {
-    const openaiApiKey = window.config.services.openai?.apiKey;
+    const provider = this.ttsConfig.provider || 'openai';
 
-    if (!openaiApiKey) {
-      console.error('OpenAI API key not found for TTS. Please ensure your OpenAI API key is configured.');
-      return null;
+    if (provider === 'xai') {
+      return await generateSpeechXai(text);
     }
-
-    let instructions = this.ttsConfig.instructions || '';
-
-    if (!instructions && this.personalityPromptRadio?.checked &&
-        this.personalityInput?.value.trim() !== '' &&
-        this.personalityInput?.getAttribute('data-explicitly-set') === 'true') {
-      instructions = `Assume the personality of ${this.personalityInput.value.trim()}. Roleplay and never break character.  Do not read code blocks that appear between backticks or other non-speech content such as emotes which appear between asterisks in *italics* like that.`;
-    }
-
-    if (!instructions) {
-      instructions = 'Speak in a natural, conversational tone.';
-    }
-
-    const requestBody = {
-      model: 'gpt-4o-mini-tts',
-      input: text,
-      voice: this.ttsConfig.voice,
-      instructions,
-      response_format: 'wav',
-    };
-
-    const headers = {
-      Authorization: `Bearer ${openaiApiKey}`,
-      'Content-Type': 'application/json',
-    };
-
-    const response = await fetch('https://api.openai.com/v1/audio/speech', {
-      method: 'POST',
-      headers,
-      body: JSON.stringify(requestBody),
-    });
-
-    if (!response.ok) {
-      let errorDetails = '';
-      try {
-        const errorData = await response.json();
-        errorDetails = errorData.error?.message || JSON.stringify(errorData);
-      } catch {
-        errorDetails = `HTTP ${response.status} - ${response.statusText}`;
-      }
-      throw new Error(`TTS API request failed: ${errorDetails}`);
-    }
-
-    return await response.arrayBuffer();
+    return await generateSpeechOpenai(text);
   } catch (error) {
     console.error('TTS generation error:', error);
     return null;
   }
 };
 
+async function generateSpeechOpenai(text) {
+  const openaiApiKey = window.config.services.openai?.apiKey;
+
+  if (!openaiApiKey) {
+    console.error('OpenAI API key not found for TTS. Please ensure your OpenAI API key is configured.');
+    return null;
+  }
+
+  let instructions = window.ttsConfig.instructions || '';
+
+  if (!instructions && window.personalityPromptRadio?.checked &&
+      window.personalityInput?.value.trim() !== '' &&
+      window.personalityInput?.getAttribute('data-explicitly-set') === 'true') {
+    instructions = `Assume the personality of ${window.personalityInput.value.trim()}. Roleplay and never break character.  Do not read code blocks that appear between backticks or other non-speech content such as emotes which appear between asterisks in *italics* like that.`;
+  }
+
+  if (!instructions) {
+    instructions = 'Speak in a natural, conversational tone.';
+  }
+
+  const requestBody = {
+    model: 'gpt-4o-mini-tts',
+    input: text,
+    voice: window.ttsConfig.voice,
+    instructions,
+    response_format: 'wav',
+  };
+
+  const response = await fetch('https://api.openai.com/v1/audio/speech', {
+    method: 'POST',
+    headers: {
+      Authorization: `Bearer ${openaiApiKey}`,
+      'Content-Type': 'application/json',
+    },
+    body: JSON.stringify(requestBody),
+  });
+
+  if (!response.ok) {
+    let errorDetails = '';
+    try {
+      const errorData = await response.json();
+      errorDetails = errorData.error?.message || JSON.stringify(errorData);
+    } catch {
+      errorDetails = `HTTP ${response.status} - ${response.statusText}`;
+    }
+    throw new Error(`TTS API request failed: ${errorDetails}`);
+  }
+
+  return await response.arrayBuffer();
+}
+
+async function generateSpeechXai(text) {
+  const xaiApiKey = window.config.services.xai?.apiKey;
+
+  if (!xaiApiKey) {
+    console.error('xAI API key not found for TTS. Please ensure your xAI API key is configured.');
+    return null;
+  }
+
+  const requestBody = {
+    text,
+    voice_id: window.ttsConfig.voice,
+    language: 'auto',
+    output_format: {
+      codec: 'wav',
+      sample_rate: 24000,
+    },
+  };
+
+  const response = await fetch('https://api.x.ai/v1/tts', {
+    method: 'POST',
+    headers: {
+      Authorization: `Bearer ${xaiApiKey}`,
+      'Content-Type': 'application/json',
+    },
+    body: JSON.stringify(requestBody),
+  });
+
+  if (!response.ok) {
+    let errorDetails = '';
+    try {
+      const errorData = await response.json();
+      errorDetails = errorData.error?.message || JSON.stringify(errorData);
+    } catch {
+      errorDetails = `HTTP ${response.status} - ${response.statusText}`;
+    }
+    throw new Error(`xAI TTS API request failed: ${errorDetails}`);
+  }
+
+  return await response.arrayBuffer();
+}

--- a/src/js/services/tts/config.js
+++ b/src/js/services/tts/config.js
@@ -1,6 +1,7 @@
 // TTS configuration object and basic runtime state
 window.ttsConfig = {
   enabled: false,
+  provider: 'openai',
   voice: 'ash',
   instructions: '',
   autoplay: true,
@@ -21,27 +22,40 @@ window.ttsMessageQueue = [];
 window.ttsAutoplayActive = false;
 window.ttsErrorShown = false;
 
-// Hint available voices to the UI
+// Hint available voices to the UI (per provider)
 window.availableTtsVoices = {
-  neutral: [
-    { id: 'fable', name: 'Fable', gender: 'Neutral' },
-  ],
-  male: [
-    { id: 'ash', name: 'Ash', gender: 'Male' },
-    { id: 'ballad', name: 'Ballad', gender: 'Male' },
-    { id: 'cedar', name: 'Cedar', gender: 'Male' },
-    { id: 'echo', name: 'Echo', gender: 'Male' },
-    { id: 'onyx', name: 'Onyx', gender: 'Male' },
-    { id: 'verse', name: 'Verse', gender: 'Male' },
-  ],
-  female: [
-    { id: 'alloy', name: 'Alloy', gender: 'Female' },
-    { id: 'coral', name: 'Coral', gender: 'Female' },
-    { id: 'marin', name: 'Marin', gender: 'Female' },
-    { id: 'nova', name: 'Nova', gender: 'Female' },
-    { id: 'sage', name: 'Sage', gender: 'Female' },
-    { id: 'shimmer', name: 'Shimmer', gender: 'Female' },
-  ],
+  openai: {
+    neutral: [
+      { id: 'fable', name: 'Fable', gender: 'Neutral' },
+    ],
+    male: [
+      { id: 'ash', name: 'Ash', gender: 'Male' },
+      { id: 'ballad', name: 'Ballad', gender: 'Male' },
+      { id: 'cedar', name: 'Cedar', gender: 'Male' },
+      { id: 'echo', name: 'Echo', gender: 'Male' },
+      { id: 'onyx', name: 'Onyx', gender: 'Male' },
+      { id: 'verse', name: 'Verse', gender: 'Male' },
+    ],
+    female: [
+      { id: 'alloy', name: 'Alloy', gender: 'Female' },
+      { id: 'coral', name: 'Coral', gender: 'Female' },
+      { id: 'marin', name: 'Marin', gender: 'Female' },
+      { id: 'nova', name: 'Nova', gender: 'Female' },
+      { id: 'sage', name: 'Sage', gender: 'Female' },
+      { id: 'shimmer', name: 'Shimmer', gender: 'Female' },
+    ],
+  },
+  xai: {
+    male: [
+      { id: 'leo', name: 'Leo', gender: 'Male' },
+      { id: 'rex', name: 'Rex', gender: 'Male' },
+      { id: 'sal', name: 'Sal', gender: 'Male' },
+    ],
+    female: [
+      { id: 'ara', name: 'Ara', gender: 'Female' },
+      { id: 'eve', name: 'Eve', gender: 'Female' },
+    ],
+  },
 };
 
 // Lazy-load audio storage helpers if needed

--- a/src/js/services/tts/init.js
+++ b/src/js/services/tts/init.js
@@ -1,6 +1,7 @@
 window.initTtsReferences = function(refs) {
   this.ttsToggle = refs.ttsToggle;
   this.ttsAutoplayToggle = refs.ttsAutoplayToggle;
+  this.ttsProviderSelector = refs.ttsProviderSelector;
   this.ttsVoiceSelector = refs.ttsVoiceSelector;
   this.ttsInstructionsInput = refs.ttsInstructionsInput;
   this.personalityInput = refs.personalityInput;


### PR DESCRIPTION
## Summary
- Add xAI (Grok) as a selectable TTS provider alongside OpenAI with 5 voices (leo, rex, sal, ara, eve)
- New provider selector in Settings → TTS dynamically updates voice list and hides unsupported options (voice instructions hidden for xAI)
- TTS voice selector now populates on page load instead of only when TTS is enabled
- Version bump to v1.4.0

## Test plan
- [ ] Select xAI as TTS provider and verify voice list updates to xAI voices
- [ ] Switch back to OpenAI and verify original voices return
- [ ] Test xAI TTS generation with a valid xAI API key
- [ ] Verify voice instructions field hides when xAI is selected
- [ ] Confirm voice selector is populated on page load without enabling TTS first
- [ ] Test voice button in settings for both providers

🤖 Generated with [Claude Code](https://claude.com/claude-code)