### PR TITLE
Add xAI direct file attachment support

### DIFF
--- a/docs/services.md
+++ b/docs/services.md
@@ -19,6 +19,7 @@ Defined in `src/config/config.js` under `window.config.services` with a `default
   - Supports MCP connectors; local-network servers remain blocked for security when using xAI
   - Requires `text.format` removal when using server-side tools (web/X search, Code Interpreter, MCP connectors)
   - Provider-managed Code Interpreter ignores OpenAI-specific container options
+  - File attachments use direct `input_file` references (uploaded via `/v1/files`, referenced by `file_id` in message content) instead of vector stores
 - **LM Studio** (`lmstudio`) - Local OpenAI-compatible server
   - Models fetched dynamically via `<baseUrl>/models`
   - No API key required
@@ -71,7 +72,7 @@ Tools are managed by `src/js/services/api/toolManager.js`:
 - **Web Search** (`builtin:web_search`) - Provider-managed web search; xAI also surfaces `x_search` for Twitter/X
 - **Code Interpreter** (`builtin:code_interpreter`) - Python sandbox execution
 - **Image Generation** (`builtin:image_generation`) - OpenAI DALL-E integration (automatically disabled when Codex models are selected)
-- **File Search** (`builtin:file_search`) - Vector store lookup for uploaded documents
+- **File Search** (`builtin:file_search`) - Vector store lookup for uploaded documents (OpenAI only)
 
 ### MCP Servers
 - User-configured servers registered via `registerMcpServer()`
@@ -114,13 +115,20 @@ See [Streaming](./streaming.md) for details on reasoning display formatting.
 
 ## File & Vector Store Services
 
-- `src/js/services/files.js` exposes helpers to list, delete, and bulk-delete assistants files. All requests are authorised via `ensureApiKey()` and point at `getBaseUrl()`.
-  - `listAssistantFiles()` filters by `purpose=assistants`
-  - `deleteAllAssistantFiles()` aggregates successes/errors so the UI can surface partial failures
-- `src/js/services/vectorStore.js` covers upload + attachment workflows, creation/deletion, polling, and local metadata storage.
+Document attachments are handled differently per provider:
+
+- **OpenAI**: Files are uploaded to `/v1/files`, attached to a vector store, and searched via the `file_search` tool. Requires the File Search tool to be enabled in Settings.
+- **xAI**: Files are uploaded to `/v1/files` and referenced directly in message content as `input_file` parts with the returned `file_id`. No vector stores or file_search tool needed.
+
+Shared infrastructure in `src/js/services/vectorStore.js`:
+  - `uploadFile()` uploads a file to the active provider's `/files` endpoint (used by both OpenAI and xAI)
   - `filterSupportedFiles()` blocks unsupported extensions before upload
-  - `uploadAndAttachFiles()` batches uploads, attaches them to a newly created store, and reports skipped items
+  - `uploadAndAttachFiles()` batches uploads and attaches them to a newly created vector store (OpenAI path)
   - `saveVectorStoreMetadata()` / `getVectorStoreMetadata()` persist IDs + names so the UI can pre-populate selectors
   - `waitForFileProcessing()` polls `vector_stores/{id}/files/{fileId}` until `completed`, raising on `failed`/timeout
 
-These flows are covered by `tests/filesService.spec.js` and `tests/vectorStoreService.spec.js`, which stub `fetch` to ensure we make the correct REST calls and handle error paths gracefully.
+`src/js/services/files.js` exposes helpers to list, delete, and bulk-delete assistants files. All requests are authorised via `ensureApiKey()` and point at `getBaseUrl()`.
+  - `listAssistantFiles()` filters by `purpose=assistants`
+  - `deleteAllAssistantFiles()` aggregates successes/errors so the UI can surface partial failures
+
+These flows are covered by `tests/filesService.spec.js`, `tests/vectorStoreService.spec.js`, and `tests/messageUtils.spec.js`.

--- a/docs/tool-calling.md
+++ b/docs/tool-calling.md
@@ -22,7 +22,7 @@ Built-in Tools
 - `web_search` (type: `builtin`) — Provider-managed web search (OpenAI, xAI). For xAI, also includes `x_search` for Twitter/X search.
 - `code_interpreter` (type: `builtin`) — Python code execution in provider sandbox (OpenAI, xAI). Outputs handled by `src/js/services/streaming/codeInterpreter.js`.
 - `image_generation` (type: `builtin`) — OpenAI image generation. Outputs processed by `src/js/services/streaming/imageGeneration.js`.
-- `file_search` (type: `builtin`) — Vector store search across uploaded documents. Rendered in reasoning timeline.
+- `file_search` (type: `builtin`) — Vector store search across uploaded documents (OpenAI only). Rendered in reasoning timeline. xAI uses direct `input_file` references instead.
 - MCP connectors (type: `mcp`) — User-supplied servers registered in Settings → Tools. Availability depends on the external MCP server responding to ping checks.
 
 Credentials

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "wordmark",
-  "version": "1.4.0",
+  "version": "1.5.0",
   "description": "Client-side AI assistant for the OpenAI Responses API and local LM Studio servers.",
   "main": "index.html",
   "type": "module",

--- a/src/config/config.js
+++ b/src/config/config.js
@@ -18,7 +18,7 @@ window.MCP_ASSUME_ONLINE = true;
 // DO NOT hardcode actual API keys here
 
 // Application version
-window.APP_VERSION = '1.4.0';
+window.APP_VERSION = '1.5.0';
 
 // GitHub repository URL
 window.GITHUB_URL = 'https://github.com/h1ddenpr0cess20/Wordmark';

--- a/src/js/components/interaction.js
+++ b/src/js/components/interaction.js
@@ -212,70 +212,112 @@ window.sendMessage = async function() {
   window.activeLoadingMessageId = loadingId;
   window.isResponsePending = true;
 
-  // Handle document uploads if present - use existing vector store if available
+  // Handle document uploads if present
   let vectorStoreId = window.activeVectorStore || null;
+  const activeServiceKey = window.serviceSelector ? window.serviceSelector.value : "openai";
   if (hasDocuments) {
     console.log("Has documents:", documentsToUpload.length);
-    console.log("File search enabled:", window.responsesClient?.isToolEnabled("builtin:file_search"));
 
-    if (!window.responsesClient?.isToolEnabled("builtin:file_search")) {
-      console.warn("File Search tool is not enabled. Documents will not be uploaded.");
-      if (window.showInfo) {
-        window.showInfo("Enable File Search tool in settings to upload documents");
+    // Flatten files from directories and individual uploads
+    const files = [];
+    documentsToUpload.forEach(doc => {
+      if (doc.isDirectory) {
+        doc.files.forEach(f => files.push(f.file));
+      } else {
+        files.push(doc.file);
       }
-    } else {
+    });
+
+    if (activeServiceKey === "xai") {
+      // xAI: upload files and attach as input_file references directly in the message
       try {
-        console.info("Uploading documents to vector store...");
-
-        // Show status message to user
         if (window.showInfo) {
-          window.showInfo("Creating vector store and uploading documents...");
+          window.showInfo("Uploading files...");
         }
 
-        const { uploadAndAttachFiles } = await import("../services/vectorStore.js");
+        const { uploadFile } = await import("../services/vectorStore.js");
+        const fileIds = [];
+        for (const file of files) {
+          const uploaded = await uploadFile(file);
+          fileIds.push(uploaded.id);
+        }
 
-        // Flatten files from directories and individual uploads
-        const files = [];
-        documentsToUpload.forEach(doc => {
-          if (doc.isDirectory) {
-            doc.files.forEach(f => files.push(f.file));
-          } else {
-            files.push(doc.file);
+        // Inject input_file parts into the last user message in conversation history
+        const lastUserMsg = window.conversationHistory[window.conversationHistory.length - 1];
+        if (lastUserMsg && lastUserMsg.role === "user") {
+          const fileParts = fileIds.map(id => ({ type: "input_file", file_id: id }));
+          if (typeof lastUserMsg.content === "string") {
+            const textPart = { type: "input_text", text: lastUserMsg.content };
+            lastUserMsg.content = [textPart, ...fileParts];
+          } else if (Array.isArray(lastUserMsg.content)) {
+            lastUserMsg.content.push(...fileParts);
           }
-        });
-
-        console.log("Files to upload:", files.map(f => f.name));
-        const result = await uploadAndAttachFiles(files, `Chat-${Date.now()}`);
-        vectorStoreId = result.vectorStoreId;
-        window.activeVectorStore = vectorStoreId;
-
-        // Save vector store metadata
-        if (typeof window.saveVectorStoreMetadata === "function") {
-          window.saveVectorStoreMetadata(vectorStoreId, {
-            name: `Chat-${Date.now()}`,
-            createdAt: Date.now(),
-            fileCount: files.length,
-          });
         }
 
-        console.info("Documents uploaded to vector store:", vectorStoreId);
-
-        // Show success message
+        console.info("Files uploaded for xAI:", fileIds);
         if (window.showInfo) {
-          const uploadedCount = files.length - (result.skipped || 0);
-          const message = result.skipped > 0
-            ? `Vector store created with ${uploadedCount} file(s). ${result.skipped} file(s) skipped.`
-            : `Vector store created with ${uploadedCount} file(s)`;
-          window.showInfo(message);
+          window.showInfo(`${fileIds.length} file(s) uploaded`);
         }
       } catch (error) {
-        console.error("Failed to upload documents:", error);
+        console.error("Failed to upload files:", error);
         if (window.showError) {
-          window.showError(`Failed to upload documents: ${error.message}`);
+          window.showError(`Failed to upload files: ${error.message}`);
         }
         window.removeLoadingIndicator(loadingId);
         window.resetSendButton();
         return;
+      }
+    } else {
+      // OpenAI: use vector stores + file_search
+      console.log("File search enabled:", window.responsesClient?.isToolEnabled("builtin:file_search"));
+
+      if (!window.responsesClient?.isToolEnabled("builtin:file_search")) {
+        console.warn("File Search tool is not enabled. Documents will not be uploaded.");
+        if (window.showInfo) {
+          window.showInfo("Enable File Search tool in settings to upload documents");
+        }
+      } else {
+        try {
+          console.info("Uploading documents to vector store...");
+
+          if (window.showInfo) {
+            window.showInfo("Creating vector store and uploading documents...");
+          }
+
+          const { uploadAndAttachFiles } = await import("../services/vectorStore.js");
+
+          console.log("Files to upload:", files.map(f => f.name));
+          const result = await uploadAndAttachFiles(files, `Chat-${Date.now()}`);
+          vectorStoreId = result.vectorStoreId;
+          window.activeVectorStore = vectorStoreId;
+
+          // Save vector store metadata
+          if (typeof window.saveVectorStoreMetadata === "function") {
+            window.saveVectorStoreMetadata(vectorStoreId, {
+              name: `Chat-${Date.now()}`,
+              createdAt: Date.now(),
+              fileCount: files.length,
+            });
+          }
+
+          console.info("Documents uploaded to vector store:", vectorStoreId);
+
+          if (window.showInfo) {
+            const uploadedCount = files.length - (result.skipped || 0);
+            const message = result.skipped > 0
+              ? `Vector store created with ${uploadedCount} file(s). ${result.skipped} file(s) skipped.`
+              : `Vector store created with ${uploadedCount} file(s)`;
+            window.showInfo(message);
+          }
+        } catch (error) {
+          console.error("Failed to upload documents:", error);
+          if (window.showError) {
+            window.showError(`Failed to upload documents: ${error.message}`);
+          }
+          window.removeLoadingIndicator(loadingId);
+          window.resetSendButton();
+          return;
+        }
       }
     }
   }

--- a/tests/fileSearchVectorStores.spec.js
+++ b/tests/fileSearchVectorStores.spec.js
@@ -144,11 +144,9 @@ test('file_search attaches all active vector stores from storage when none provi
     ? capturedBody.tools.find(t => t && t.type === 'file_search')
     : null;
   assert.ok(fileSearchTool, 'file_search tool should be included');
-  // Order not guaranteed, compare as sets
+  // MAX_ACTIVE_VECTOR_STORES is 2, so only the active store + 1 from metadata
   const ids = new Set(fileSearchTool.vector_store_ids);
-  assert.equal(ids.size, 3, 'should include three vector store ids from storage');
-  assert.ok(ids.has('vs_A'), 'includes vs_A');
-  assert.ok(ids.has('vs_B'), 'includes vs_B');
+  assert.equal(ids.size, 2, 'should include two vector store ids (capped by MAX_ACTIVE_VECTOR_STORES)');
   assert.ok(ids.has('vs_C'), 'includes vs_C (active)');
 });
 

--- a/tests/messageUtils.spec.js
+++ b/tests/messageUtils.spec.js
@@ -32,6 +32,32 @@ test('serializeMessagesForRequest includes input_image parts for inline attachme
   assert.equal(textPart.text, 'Please describe this upload.');
 });
 
+test('serializeMessagesForRequest passes through input_file parts for xAI file attachments', () => {
+  window.imageDataCache = new Map();
+  window.generatedImages = [];
+
+  const [serialized] = serializeMessagesForRequest([{
+    role: 'user',
+    content: [
+      { type: 'input_text', text: 'Summarize this document.' },
+      { type: 'input_file', file_id: 'file-abc123' },
+      { type: 'input_file', file_id: 'file-def456' },
+    ],
+  }]);
+
+  assert.ok(Array.isArray(serialized.content), 'content should be an array');
+  assert.equal(serialized.content.length, 3, 'should have three content parts');
+
+  const textPart = serialized.content.find(part => part.type === 'input_text');
+  assert.ok(textPart, 'expected an input_text part');
+  assert.equal(textPart.text, 'Summarize this document.');
+
+  const fileParts = serialized.content.filter(part => part.type === 'input_file');
+  assert.equal(fileParts.length, 2, 'expected two input_file parts');
+  assert.equal(fileParts[0].file_id, 'file-abc123');
+  assert.equal(fileParts[1].file_id, 'file-def456');
+});
+
 test('serializeMessagesForRequest resolves gallery placeholders to input_image parts', () => {
   window.imageDataCache = new Map();
   window.generatedImages = [{


### PR DESCRIPTION
## Summary
- xAI file attachments now use direct `input_file` references in message content (uploaded via `/v1/files`, referenced by `file_id`) instead of vector stores, per the [xAI docs](https://docs.x.ai/developers/model-capabilities/files/chat-with-files)
- OpenAI continues using the existing vector store + `file_search` approach
- Version bumped to v1.5.0
- Documentation updated to reflect per-provider file handling differences
- Fixed pre-existing test that expected 3 vector store IDs despite `MAX_ACTIVE_VECTOR_STORES` being 2

## Test plan
- [x] `messageUtils.spec.js` — new test verifying `input_file` parts pass through serialization
- [x] `fileSearchVectorStores.spec.js` — fixed and passing
- [x] `vectorStoreService.spec.js` — existing tests still pass
- [ ] Manual: attach a document when using xAI, verify it uploads and the model can read its contents
- [ ] Manual: attach a document when using OpenAI, verify vector store flow still works

🤖 Generated with [Claude Code](https://claude.com/claude-code)