### PR TITLE
Fix model refresh status and rename generic identifiers

### DIFF
--- a/src/config/config.js
+++ b/src/config/config.js
@@ -228,8 +228,8 @@ window.config = {
                     this.modelsFetching = false;
                 }
 
-                if (typeof window.uiHooks !== 'undefined' && typeof window.uiHooks.updateLmStudioModelsDropdown === 'function') {
-                    window.uiHooks.updateLmStudioModelsDropdown(this.models[0]?.startsWith('Error'));
+                if (typeof window.uiHooks !== 'undefined' && typeof window.uiHooks.updateModelsDropdown === 'function') {
+                    window.uiHooks.updateModelsDropdown(this.models[0]?.startsWith('Error'));
                 }
             },
         },
@@ -290,10 +290,10 @@ window.config = {
                 }
 
                 // Attempt to update UI
-                if (typeof window.uiHooks !== 'undefined' && typeof window.uiHooks.updateLmStudioModelsDropdown === 'function') {
-                    window.uiHooks.updateLmStudioModelsDropdown(fetchError);
+                if (typeof window.uiHooks !== 'undefined' && typeof window.uiHooks.updateModelsDropdown === 'function') {
+                    window.uiHooks.updateModelsDropdown(fetchError);
                 } else {
-                    console.warn('window.uiHooks.updateLmStudioModelsDropdown function not found. UI will not be updated with new LM Studio models.');
+                    console.warn('window.uiHooks.updateModelsDropdown function not found. UI will not be updated with new LM Studio models.');
                 }
             },
         },
@@ -386,10 +386,10 @@ window.config = {
                 this.modelsFetching = false;
 
                 // Attempt to update UI
-                if (typeof window.uiHooks !== 'undefined' && typeof window.uiHooks.updateLmStudioModelsDropdown === 'function') {
-                    window.uiHooks.updateLmStudioModelsDropdown(fetchError);
+                if (typeof window.uiHooks !== 'undefined' && typeof window.uiHooks.updateModelsDropdown === 'function') {
+                    window.uiHooks.updateModelsDropdown(fetchError);
                 } else {
-                    console.warn('window.uiHooks.updateLmStudioModelsDropdown function not found. UI will not be updated with new Ollama models.');
+                    console.warn('window.uiHooks.updateModelsDropdown function not found. UI will not be updated with new Ollama models.');
                 }
             },
         },
@@ -450,8 +450,8 @@ window.config = {
                     this.modelsFetching = false;
                 }
 
-                if (typeof window.uiHooks !== 'undefined' && typeof window.uiHooks.updateLmStudioModelsDropdown === 'function') {
-                    window.uiHooks.updateLmStudioModelsDropdown(this.models[0]?.startsWith('Error'));
+                if (typeof window.uiHooks !== 'undefined' && typeof window.uiHooks.updateModelsDropdown === 'function') {
+                    window.uiHooks.updateModelsDropdown(this.models[0]?.startsWith('Error'));
                 }
             },
         },

--- a/src/css/components/ui/api-keys.css
+++ b/src/css/components/ui/api-keys.css
@@ -116,7 +116,8 @@
   z-index: 1;
 }
 
-/* Local server status messages */
+/* Service status messages */
+.service-status,
 .lmstudio-status,
 .ollama-status {
   text-align: center;
@@ -127,6 +128,7 @@
   animation: fadeIn 0.3s ease-in-out;
 }
 
+.service-status.success,
 .lmstudio-status.success,
 .ollama-status.success {
   background-color: var(--success-bg, rgba(0, 128, 0, 0.1));
@@ -134,6 +136,7 @@
   border: 1px solid var(--success-border, rgba(0, 128, 0, 0.2));
 }
 
+.service-status.error,
 .lmstudio-status.error,
 .ollama-status.error {
   background-color: var(--error-bg, rgba(255, 0, 0, 0.1));

--- a/src/html/panels/settings/model.html
+++ b/src/html/panels/settings/model.html
@@ -10,11 +10,11 @@
     <label for="model-selector">AI Model</label>
     <div class="model-selector-container">
       <select id="model-selector"></select>
-      <button type="button" id="refresh-lmstudio-models" class="small-button" title="Refresh Models" aria-label="Refresh models">
+      <button type="button" id="refresh-models" class="small-button" title="Refresh Models" aria-label="Refresh models">
         <svg xmlns="http://www.w3.org/2000/svg" width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><use href="src/assets/icons.svg#refresh-cw"></use></svg>
       </button>
     </div>
-    <p class="info-text lmstudio-refresh-info hidden">Click the refresh button to update the list of available models.</p>
+    <p class="info-text refresh-models-info hidden">Click the refresh button to update the list of available models.</p>
   </div>
   <div class="setting-item">
     <label for="reasoning-effort">Reasoning Effort</label>

--- a/src/js/components/settings.js
+++ b/src/js/components/settings.js
@@ -13,37 +13,35 @@ window.uiHooks = window.uiHooks || {};
  * Updates the local models dropdown when models are refreshed
  * @param {boolean} fetchError - Whether there was an error fetching models
  */
-window.uiHooks.updateLmStudioModelsDropdown = function(fetchError) {
+window.uiHooks.updateModelsDropdown = function(fetchError) {
   const serviceKey = window.serviceSelector ? window.serviceSelector.value : "";
-  const isLocalService = serviceKey === "lmstudio" || serviceKey === "ollama";
-  const serviceLabel = serviceKey === "lmstudio" ? "LM Studio" : serviceKey === "ollama" ? "Ollama" : "Local";
+  const serviceLabelMap = { lmstudio: "LM Studio", ollama: "Ollama", openai: "OpenAI", xai: "xAI" };
+  const serviceLabel = serviceLabelMap[serviceKey] || serviceKey;
 
-  if (isLocalService) {
-    window.updateModelSelector();
+  window.updateModelSelector();
 
-    // Show status message if there was an error
-    if (fetchError) {
-      // Remove any existing status message
-      const existingStatus = document.querySelector(".lmstudio-status");
-      if (existingStatus) {
-        existingStatus.remove();
-      }
+  // Show status message if there was an error
+  if (fetchError) {
+    // Remove any existing status message
+    const existingStatus = document.querySelector(".service-status");
+    if (existingStatus) {
+      existingStatus.remove();
+    }
 
-      // Create a new status message
-      const statusElement = document.createElement("div");
-      statusElement.className = "lmstudio-status error";
-      statusElement.textContent = `Failed to fetch ${serviceLabel} models. Check server connection.`;
+    // Create a new status message
+    const statusElement = document.createElement("div");
+    statusElement.className = "service-status error";
+    statusElement.textContent = `Failed to fetch ${serviceLabel} models. Check server connection.`;
 
-      // Add status message to the DOM
-      const statusAnchor = document.querySelector(".model-selector-container") || document.querySelector(".lmstudio-action-buttons");
-      if (statusAnchor) {
-        statusAnchor.insertAdjacentElement("afterend", statusElement);
+    // Add status message to the DOM
+    const statusAnchor = document.querySelector(".model-selector-container") || document.querySelector(".lmstudio-action-buttons");
+    if (statusAnchor) {
+      statusAnchor.insertAdjacentElement("afterend", statusElement);
 
-        // Auto-remove after 5 seconds
-        setTimeout(() => {
-          statusElement.remove();
-        }, 5000);
-      }
+      // Auto-remove after 5 seconds
+      setTimeout(() => {
+        statusElement.remove();
+      }, 5000);
     }
   }
 };

--- a/src/js/components/ui/settingsControls.js
+++ b/src/js/components/ui/settingsControls.js
@@ -41,8 +41,8 @@ window.updateParameterControls = function() {
   const serviceConfig = currentService ? window.config?.services?.[currentService] : null;
   const hasDynamicModels = serviceConfig && typeof serviceConfig.fetchAndUpdateModels === 'function';
 
-  const refreshButton = document.getElementById('refresh-lmstudio-models');
-  const refreshInfo = document.querySelector('.lmstudio-refresh-info');
+  const refreshButton = document.getElementById('refresh-models');
+  const refreshInfo = document.querySelector('.refresh-models-info');
 
   if (refreshButton) {
     refreshButton.style.display = hasDynamicModels ? 'flex' : 'none';

--- a/src/js/init/eventListeners/buttons.js
+++ b/src/js/init/eventListeners/buttons.js
@@ -158,9 +158,9 @@ export function setupButtonEventListeners({ closeSettingsPanel } = {}) {
     });
   }
 
-  const refreshLmStudioModelsButton = document.getElementById('refresh-lmstudio-models');
-  if (refreshLmStudioModelsButton) {
-    refreshLmStudioModelsButton.addEventListener('click', async(event) => {
+  const refreshModelsButton = document.getElementById('refresh-models');
+  if (refreshModelsButton) {
+    refreshModelsButton.addEventListener('click', async(event) => {
       event.preventDefault();
       event.stopPropagation();
       event.stopImmediatePropagation();
@@ -170,21 +170,26 @@ export function setupButtonEventListeners({ closeSettingsPanel } = {}) {
       if (serviceConfig && typeof serviceConfig.fetchAndUpdateModels === 'function') {
         const serviceLabelMap = { lmstudio: 'LM Studio', ollama: 'Ollama', openai: 'OpenAI', xai: 'xAI' };
         const serviceLabel = serviceLabelMap[serviceKey] || serviceKey;
-        refreshLmStudioModelsButton.disabled = true;
-        refreshLmStudioModelsButton.innerHTML = window.icon('refresh-cw', { width: 16, height: 16, className: 'rotating-svg' });
+        refreshModelsButton.disabled = true;
+        refreshModelsButton.innerHTML = window.icon('refresh-cw', { width: 16, height: 16, className: 'rotating-svg' });
 
         try {
           await serviceConfig.fetchAndUpdateModels();
           window.updateModelSelector();
 
-          const existingStatus = document.querySelector('.lmstudio-status');
+          const models = serviceConfig.models || [];
+          const hasError = models.length === 0 || models.some(m => typeof m === 'string' && (m.startsWith('Error:') || m.startsWith('No models')));
+
+          const existingStatus = document.querySelector('.service-status');
           if (existingStatus) {
             existingStatus.remove();
           }
 
           const statusElement = document.createElement('div');
-          statusElement.className = 'lmstudio-status success';
-          statusElement.textContent = `${serviceLabel} models updated successfully!`;
+          statusElement.className = hasError ? 'service-status error' : 'service-status success';
+          statusElement.textContent = hasError
+            ? `Failed to refresh ${serviceLabel} models`
+            : `${serviceLabel} models updated successfully!`;
 
           const statusAnchor = document.querySelector('.model-selector-container') || document.querySelector('.lmstudio-action-buttons');
           if (statusAnchor) {
@@ -194,13 +199,13 @@ export function setupButtonEventListeners({ closeSettingsPanel } = {}) {
         } catch (error) {
           console.error(`Error refreshing ${serviceLabel} models:`, error);
 
-          const existingStatus = document.querySelector('.lmstudio-status');
+          const existingStatus = document.querySelector('.service-status');
           if (existingStatus) {
             existingStatus.remove();
           }
 
           const statusElement = document.createElement('div');
-          statusElement.className = 'lmstudio-status error';
+          statusElement.className = 'service-status error';
           statusElement.textContent = `Failed to refresh ${serviceLabel} models`;
 
           const statusAnchor = document.querySelector('.model-selector-container') || document.querySelector('.lmstudio-action-buttons');
@@ -209,8 +214,8 @@ export function setupButtonEventListeners({ closeSettingsPanel } = {}) {
             setTimeout(() => statusElement.remove(), 5000);
           }
         } finally {
-          refreshLmStudioModelsButton.disabled = false;
-          refreshLmStudioModelsButton.innerHTML = window.icon('refresh-cw', { width: 16, height: 16 });
+          refreshModelsButton.disabled = false;
+          refreshModelsButton.innerHTML = window.icon('refresh-cw', { width: 16, height: 16 });
         }
       }
     });


### PR DESCRIPTION
## Summary
- Fix model refresh button always showing "success" even when fetch failed (fetchAndUpdateModels catches errors internally, so the try/catch in the button handler never hit the error path)
- Rename lmstudio-specific IDs, classes, and function names to generic service-agnostic names since they're shared across all providers (OpenAI, xAI, LM Studio, Ollama)

## Test plan
- [ ] Switch to each service provider and click the refresh models button
- [ ] Verify success message appears when models load correctly
- [ ] Verify error message appears when fetch fails (e.g. no API key, server unreachable)
- [ ] All 114 existing tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)