### PR TITLE
Re-enable API response storage for conversation chaining

### DIFF
--- a/src/js/services/api/requestClient.js
+++ b/src/js/services/api/requestClient.js
@@ -51,7 +51,7 @@ export function buildRequestBody({
       verbosity: verbosity || DEFAULT_VERBOSITY,
     },
     input: serializeMessagesForRequest(inputMessages),
-    store: false,
+    store: true,
   };
   if (serviceKey !== 'xai' && !isLocalService) {
     payload.include = [...DEFAULT_INCLUDE_FIELDS];


### PR DESCRIPTION
## Summary
- `store: false` was set in 8fd8350 to prevent OpenAI from logging conversations, but it also broke `previous_response_id` lookups — the server can't chain responses it never persisted
- Sets `store: true` to restore multi-turn conversation functionality

## Test plan
- [ ] Verify multi-turn conversations work (responses chain correctly via `previous_response_id`)
- [ ] Confirm no regressions with tool calling across turns

🤖 Generated with [Claude Code](https://claude.com/claude-code)