### PR TITLE
Fix default-service auto-pick skipping keyed cloud providers

### DIFF
--- a/src/js/init/serviceSelection.js
+++ b/src/js/init/serviceSelection.js
@@ -1,0 +1,31 @@
+/**
+ * Pure, side-effect-free helpers for choosing the default service at startup.
+ * Kept separate from services.js (which pulls in UI modules) so the decision
+ * logic can be unit-tested without a DOM.
+ */
+
+function serviceHasKey(services, key) {
+  const svc = services && services[key];
+  return Boolean(svc && typeof svc.apiKey === "string" && svc.apiKey.trim() !== "");
+}
+
+/**
+ * Given the configured services and the current default, return another cloud
+ * provider that has an API key when the current default is a keyless cloud
+ * provider, otherwise null.
+ * @param {object} services - config.services map
+ * @param {string} current - current default service key
+ * @returns {string|null} the cloud service key to switch to, or null
+ */
+export function pickCloudFallback(services, current) {
+  const currentIsCloud = current === "openai" || current === "xai";
+  if (!currentIsCloud || serviceHasKey(services, current)) {
+    return null;
+  }
+  for (const cloud of ["openai", "xai"]) {
+    if (cloud !== current && serviceHasKey(services, cloud)) {
+      return cloud;
+    }
+  }
+  return null;
+}

--- a/src/js/init/services.js
+++ b/src/js/init/services.js
@@ -73,7 +73,10 @@ export async function selectDefaultService() {
     if (state.verboseLogging) {
       console.info(`No API key for ${current}; defaulting to ${cloudFallback}.`);
     }
-    return true;
+    // Return false (not handled) so the caller runs the standard model fetch for
+    // the now-current service — unlike the local probe below, we haven't fetched
+    // models here yet.
+    return false;
   }
 
   const isUsableModel = (m) =>

--- a/src/js/init/services.js
+++ b/src/js/init/services.js
@@ -7,6 +7,7 @@ import { updateParameterControls } from "../components/ui/settingsControls.js";
 import { updateHeaderInfo, updateModelSelector, updateFeatureStatus, populateServiceSelector } from "../components/settings.js";
 import { updateMasterToolCallingStatus, refreshToolSettingsUI } from "../components/tools.js";
 import { DEFAULT_PERSONALITY, DEFAULT_SHORT_RESPONSE_GUIDELINE, DEFAULT_SYSTEM_PROMPT, config } from "../../config/config.js";
+import { pickCloudFallback } from "./serviceSelection.js";
 
 /**
  * Initialize services and models
@@ -31,27 +32,48 @@ export function initializeServicesAndModels() {
 /**
  * Choose a sensible default provider at startup when no cloud API keys are set.
  *
- * Order: keep the current cloud default if it has a key; otherwise probe
- * LM Studio, then Ollama, and switch to the first one that returns models.
- * If none are reachable, leave the default as-is so the UI shows the usual
- * "Set API key to load models" message.
+ * Order: keep the current cloud default if it has a key; otherwise switch to the
+ * other cloud provider if it has a key; otherwise probe LM Studio, then Ollama,
+ * and switch to the first one that returns models. If none are reachable, leave
+ * the default as-is so the UI shows the usual "Set API key to load models" message.
  *
  * @returns {Promise<boolean>} true if this function already fetched models for
  *   the selected service (so the caller can skip its own model fetch).
  */
 export async function selectDefaultService() {
   const services = config?.services || {};
-  const hasCloudKey = ["openai", "xai"].some(key => {
+  const hasKey = (key) => {
     const svc = services[key];
-    return svc && typeof svc.apiKey === "string" && svc.apiKey.trim() !== "";
-  });
+    return Boolean(svc && typeof svc.apiKey === "string" && svc.apiKey.trim() !== "");
+  };
 
   const current = config?.defaultService;
   const currentIsCloud = current === "openai" || current === "xai";
 
-  // Only auto-pick when the default is a cloud provider with no key available.
-  if (hasCloudKey || !currentIsCloud) {
+  // Only auto-pick when the default is a cloud provider that has no key of its own.
+  if (!currentIsCloud || hasKey(current)) {
     return false;
+  }
+
+  const applyService = (key) => {
+    config.defaultService = key;
+    if (elements.serviceSelector) {
+      elements.serviceSelector.value = key;
+    }
+    updateModelSelector();
+    updateParameterControls();
+    updateHeaderInfo();
+  };
+
+  // The default cloud provider has no key. Prefer another cloud provider that
+  // does have a key before falling back to local services.
+  const cloudFallback = pickCloudFallback(services, current);
+  if (cloudFallback) {
+    applyService(cloudFallback);
+    if (state.verboseLogging) {
+      console.info(`No API key for ${current}; defaulting to ${cloudFallback}.`);
+    }
+    return true;
   }
 
   const isUsableModel = (m) =>
@@ -72,14 +94,7 @@ export async function selectDefaultService() {
       continue;
     }
     if (Array.isArray(svc.models) && svc.models.some(isUsableModel)) {
-      config.defaultService = local;
-      if (elements.serviceSelector) {
-        elements.serviceSelector.value = local;
-      }
-      updateModelSelector();
-
-      updateParameterControls();
-      updateHeaderInfo();
+      applyService(local);
 
       if (state.verboseLogging) {
         console.info(`No cloud API keys found; defaulting to ${local}.`);

--- a/src/js/services/apiKeyStorage.js
+++ b/src/js/services/apiKeyStorage.js
@@ -1,0 +1,31 @@
+import { config } from "../../config/config.js";
+/**
+ * DOM-free loading of API keys from localStorage into config.services.
+ *
+ * Kept separate from apiKeys.js (which pulls in the UI/notifications graph) so it
+ * has no DOM dependency and can run — and be tested — independently of whether the
+ * API-key input elements exist yet. This is the source of truth for key presence
+ * used by startup default-service selection.
+ */
+
+export const API_KEYS_STORAGE_PREFIX = "wordmark_api_key_";
+
+/**
+ * Copy each service's saved key from localStorage into config.services[key].apiKey.
+ * Blank/whitespace-only stored values are ignored.
+ */
+export function loadApiKeysIntoConfig() {
+  if (!config || !config.services || typeof localStorage === "undefined") {
+    return;
+  }
+  for (const serviceKey of Object.keys(config.services)) {
+    const service = config.services[serviceKey];
+    if (!service || typeof service !== "object") {
+      continue;
+    }
+    const stored = localStorage.getItem(`${API_KEYS_STORAGE_PREFIX}${serviceKey}`);
+    if (typeof stored === "string" && stored.trim() !== "") {
+      service.apiKey = stored;
+    }
+  }
+}

--- a/src/js/services/apiKeys.js
+++ b/src/js/services/apiKeys.js
@@ -3,6 +3,7 @@ import { updateFeatureStatus, updateModelSelector } from "../components/settings
 import { refreshToolSettingsUI } from "../components/tools.js";
 import { config } from "../../config/config.js";
 import { state } from "../init/state.js";
+import { API_KEYS_STORAGE_PREFIX, loadApiKeysIntoConfig } from "./apiKeyStorage.js";
 /**
  * API key management functionality
  */
@@ -12,7 +13,6 @@ import { state } from "../init/state.js";
 // -----------------------------------------------------
 
 // Storage keys for local storage
-const API_KEYS_STORAGE_PREFIX = "wordmark_api_key_";
 const LMSTUDIO_SERVER_URL_KEY = "wordmark_lmstudio_server_url";
 const OLLAMA_SERVER_URL_KEY = "wordmark_ollama_server_url";
 const API_KEYS_INIT_MAX_RETRIES = 40;
@@ -616,7 +616,11 @@ function getOllamaServerUrl() {
  * Ensure API keys are loaded and warn if missing
  */
 function ensureApiKeysLoaded() {
-  // Load keys if not already loaded
+  // Populate config from localStorage first, independent of the DOM, so key
+  // presence is correct even before the input elements are cached.
+  loadApiKeysIntoConfig();
+
+  // Then sync the input fields if/when they are available.
   if (typeof loadApiKeys === "function") {
     loadApiKeys();
   }

--- a/tests/apiKeysLoadIntoConfig.spec.js
+++ b/tests/apiKeysLoadIntoConfig.spec.js
@@ -1,0 +1,38 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+
+// Regression: a saved API key must reach config.services regardless of whether
+// the API-key input elements have been cached yet. Otherwise startup default-
+// service selection sees no key and falls back to a keyless provider.
+const store = new Map();
+globalThis.localStorage = {
+  getItem: (k) => (store.has(k) ? store.get(k) : null),
+  setItem: (k, v) => store.set(k, String(v)),
+  removeItem: (k) => store.delete(k),
+};
+globalThis.window = globalThis.window || {};
+
+const { config } = await import("../src/config/config.js");
+const { loadApiKeysIntoConfig } = await import("../src/js/services/apiKeyStorage.js");
+
+test("loads a saved xAI key into config without any DOM input cached", () => {
+  config.services.openai.apiKey = "";
+  config.services.xai.apiKey = "";
+  store.clear();
+  store.set("wordmark_api_key_xai", "xai-secret");
+
+  loadApiKeysIntoConfig();
+
+  assert.equal(config.services.xai.apiKey, "xai-secret");
+  assert.equal(config.services.openai.apiKey, "");
+});
+
+test("ignores blank/whitespace stored keys", () => {
+  config.services.openai.apiKey = "";
+  store.clear();
+  store.set("wordmark_api_key_openai", "   ");
+
+  loadApiKeysIntoConfig();
+
+  assert.equal(config.services.openai.apiKey, "");
+});

--- a/tests/selectDefaultService.spec.js
+++ b/tests/selectDefaultService.spec.js
@@ -1,0 +1,38 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+
+// pickCloudFallback is the pure decision behind the default-service auto-pick.
+// It must move off a keyless cloud default to another cloud provider that has a
+// key, before any local-service fallback happens.
+const { pickCloudFallback } = await import("../src/js/init/serviceSelection.js");
+
+const withKeys = ({ openai = "", xai = "" } = {}) => ({
+  openai: { apiKey: openai },
+  xai: { apiKey: xai },
+  lmstudio: {},
+  ollama: {},
+});
+
+test("switches openai -> xai when only xai has a key", () => {
+  assert.equal(pickCloudFallback(withKeys({ xai: "xai-123" }), "openai"), "xai");
+});
+
+test("switches xai -> openai when only openai has a key", () => {
+  assert.equal(pickCloudFallback(withKeys({ openai: "sk-123" }), "xai"), "openai");
+});
+
+test("returns null when the current cloud default already has a key", () => {
+  assert.equal(pickCloudFallback(withKeys({ openai: "sk-123", xai: "xai-123" }), "openai"), null);
+});
+
+test("returns null when no cloud provider has a key (defer to local probe)", () => {
+  assert.equal(pickCloudFallback(withKeys(), "openai"), null);
+});
+
+test("returns null when the default is a local service", () => {
+  assert.equal(pickCloudFallback(withKeys({ xai: "xai-123" }), "lmstudio"), null);
+});
+
+test("treats whitespace-only keys as missing", () => {
+  assert.equal(pickCloudFallback(withKeys({ openai: "   " }), "openai"), null);
+});


### PR DESCRIPTION
## Fix: default-service auto-pick skipped cloud providers that had a key

### The bug
When the app starts, `selectDefaultService()` chooses a usable provider. It computed `hasCloudKey` as "openai **or** xai has a key" and bailed out if that was true. So if you had an **xAI key** set but the default was still keyless **openai**, it saw "a cloud key exists somewhere" and did nothing — leaving the default on openai and showing the *"Set API key"* message, even though xAI was ready to go.

### The fix
When the default cloud provider has no key of its own, prefer **another cloud provider that does have a key** before falling back to local services. New order:

1. Current default has its own key → keep it
2. Default is a keyless cloud provider, another cloud provider has a key → **switch to it** *(this step was missing)*
3. No cloud key anywhere → probe LM Studio → Ollama
4. Nothing reachable → leave as-is (UI shows "Set API key")

### Testability
Extracted the decision into a pure, DOM-free `pickCloudFallback()` in `src/js/init/serviceSelection.js`; the DOM-touching parts stay in `services.js`. Added unit tests covering openai↔xai switching, keep-when-keyed, defer-to-local, local default, and whitespace-only keys.

142 tests pass; lint, HTML validation, and build are green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
