### PR TITLE
Fix Dockerfile for the TypeScript layout

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -9,7 +9,7 @@ COPY package.json package-lock.json ./
 RUN npm ci
 
 # Copy the sources Vite needs and produce the static bundle in /app/dist
-COPY vite.config.js index.html ./
+COPY vite.config.ts tsconfig.json index.html ./
 COPY src ./src
 COPY public ./public
 RUN npm run build
@@ -26,7 +26,6 @@ COPY docker/nginx.conf /etc/nginx/conf.d/default.conf
 
 # Copy the built application (static site) from the build stage
 COPY --from=build /app/dist /usr/share/nginx/html
-COPY robots.txt /usr/share/nginx/html/robots.txt
 
 # Expose HTTP and HTTPS ports
 EXPOSE 80 443


### PR DESCRIPTION
The Docker image build started failing after the 3.0.0 TypeScript conversion (the v3.0.0 tag build never published):

```
ERROR: "/vite.config.js": not found
ERROR: "/robots.txt": not found
```

Two stale references in the Dockerfile:
- `vite.config.js` was renamed to `vite.config.ts` during the conversion.
- `robots.txt` was removed (its pre-Vite `/src/js`, `/src/css` allow-paths no longer exist now that production serves the built `dist/` bundle).

This copies `vite.config.ts` + `tsconfig.json` into the build stage and drops the `robots.txt` copy. `npm run build` passes; once merged, the docker-publish workflow will rebuild `latest` and the re-pointed `v3.0.0` tag.

🤖 Generated with [Claude Code](https://claude.com/claude-code)