### PR TITLE
Refresh about/help panels for current features

### DIFF
--- a/src/html/contact.html
+++ b/src/html/contact.html
@@ -38,7 +38,7 @@
               GitHub Repository
             </h3>
             <p>The best place for bug reports, feature requests, and technical discussions.</p>
-            <a href="https://github.com/h1ddenpr0cess20/Wordmark" target="_blank" rel="noopener" class="contact-link">
+            <a href="https://github.com/h1ddenpr0cess20/wordmark" target="_blank" rel="noopener" class="contact-link">
               Visit GitHub Repository
               <span class="external-icon" aria-hidden="true">↗️</span>
             </a>
@@ -50,7 +50,7 @@
               Issues &amp; Bug Reports
             </h3>
             <p>Found a bug or have a feature request? Please open an issue on GitHub.</p>
-            <a href="https://github.com/h1ddenpr0cess20/Wordmark/issues" target="_blank" rel="noopener" class="contact-link">
+            <a href="https://github.com/h1ddenpr0cess20/wordmark/issues" target="_blank" rel="noopener" class="contact-link">
               Open an Issue
               <span class="external-icon" aria-hidden="true">↗️</span>
             </a>
@@ -62,7 +62,7 @@
               Discussions
             </h3>
             <p>Join community discussions, ask questions, and share your experience.</p>
-            <a href="https://github.com/h1ddenpr0cess20/Wordmark/discussions" target="_blank" rel="noopener" class="contact-link">
+            <a href="https://github.com/h1ddenpr0cess20/wordmark/discussions" target="_blank" rel="noopener" class="contact-link">
               Join Discussions
               <span class="external-icon" aria-hidden="true">↗️</span>
             </a>
@@ -118,7 +118,7 @@
     </main>
 
     <footer class="contact-footer">
-      <p>&copy; 2025 Dustin Whyte | <a href="../../index.html">Back to Wordmark</a></p>
+      <p>&copy; 2025–2026 Dustin Whyte | <a href="../../index.html">Back to Wordmark</a></p>
     </footer>
   </div>
 </body>

--- a/src/html/help-guide.html
+++ b/src/html/help-guide.html
@@ -113,13 +113,17 @@
         <h2>Using Advanced Features</h2>
 
         <h3>Tools and Extensions</h3>
-        <p>Wordmark supports a small set of tools that extend the AI's capabilities:</p>
+        <p>Wordmark supports a set of tools that extend the AI's capabilities. Provider-managed tools are only available while the relevant service is active:</p>
         <ul>
-          <li><strong>Web Search:</strong> Let the AI use OpenAI-managed web search for fresh information when the OpenAI service is active.</li>
-          <li><strong>Weather Information:</strong> Get short forecasts via the built-in Open-Meteo helper.</li>
+          <li><strong>Web Search:</strong> Provider-managed web search for fresh information (OpenAI or xAI).</li>
+          <li><strong>Weather Information:</strong> Short 1–7 day forecasts via the built-in Open-Meteo helper (any provider, no key required).</li>
+          <li><strong>Code Interpreter:</strong> Let the AI run Python and work with files in the provider sandbox (OpenAI or xAI).</li>
+          <li><strong>Image Generation:</strong> Generate or edit images with the OpenAI image tool, or with xAI Grok Imagine (generate and edit) when using xAI.</li>
+          <li><strong>File Search:</strong> Search uploaded documents through vector stores (OpenAI).</li>
+          <li><strong>Shell:</strong> Run shell commands in a sandboxed container (OpenAI; off by default).</li>
           <li><strong>Custom MCP Servers:</strong> Register your own MCP endpoints to unlock additional domain-specific tools.</li>
         </ul>
-        <p><strong>Note:</strong> The built-in helpers do not require extra keys. MCP servers manage their own authentication and may need credentials on their side.</p>
+        <p><strong>Note:</strong> The built-in helpers do not require extra keys (Grok Imagine needs an xAI key). MCP servers manage their own authentication and may need credentials on their side.</p>
 
         <h3>Memory</h3>
         <p>Use the Memory feature to let the assistant remember or forget brief details you provide.</p>
@@ -160,15 +164,15 @@
         <h2>Getting Help</h2>
         <p>If you need further assistance:</p>
         <ul>
-          <li>Visit the <a href="https://github.com/h1ddenpr0cess20/Wordmark" target="_blank" rel="noopener">GitHub Repository</a> for documentation and updates</li>
-          <li>Report issues on the <a href="https://github.com/h1ddenpr0cess20/Wordmark/issues" target="_blank" rel="noopener">Issues page</a></li>
-          <li>Join discussions with other users on the <a href="https://github.com/h1ddenpr0cess20/Wordmark/discussions" target="_blank" rel="noopener">Discussions forum</a></li>
+          <li>Visit the <a href="https://github.com/h1ddenpr0cess20/wordmark" target="_blank" rel="noopener">GitHub Repository</a> for documentation and updates</li>
+          <li>Report issues on the <a href="https://github.com/h1ddenpr0cess20/wordmark/issues" target="_blank" rel="noopener">Issues page</a></li>
+          <li>Join discussions with other users on the <a href="https://github.com/h1ddenpr0cess20/wordmark/discussions" target="_blank" rel="noopener">Discussions forum</a></li>
         </ul>
       </section>
     </main>
 
     <footer class="help-footer">
-      <p>&copy; 2025 Dustin Whyte | <a href="../../index.html">Back to Wordmark</a></p>
+      <p>&copy; 2025–2026 Dustin Whyte | <a href="../../index.html">Back to Wordmark</a></p>
     </footer>
   </div>
 </body>

--- a/src/html/panels/settings/about.html
+++ b/src/html/panels/settings/about.html
@@ -2,12 +2,12 @@
   <h3>About Wordmark</h3>
   <div class="about-content">
     <p>Version <span id="app-version"></span></p>
-    <p>Wordmark is an open source AI assistant that uses the Responses API with OpenAI, xAI, Ollama, and LM Studio. It offers advanced features like personality customization, tool calling (weather, OpenAI web search, and custom MCP servers), text-to-speech, theme customization, and secure local storage of conversations and API keys.</p>
+    <p>Wordmark is an open source AI assistant that uses the Responses API with OpenAI, xAI, Ollama, and LM Studio. It offers advanced features like personality customization, tool calling (weather, web search, code interpreter, image generation, file search, and custom MCP servers), text-to-speech, theme customization, and secure local storage of conversations and API keys.</p>
     <p>All of your conversations and generated images are stored locally in your browser. You can easily manage your chat history and view your images in the image gallery. Make sure to download the images you want to keep, as they are not stored on any server and will be lost if you clear your browser data.</p>
-    <p>For more information, visit the <a href="https://github.com/h1ddenpr0cess20/Wordmark" target="_blank" rel="noopener">GitHub Repository</a>.</p>
+    <p>For more information, visit the <a href="https://github.com/h1ddenpr0cess20/wordmark" target="_blank" rel="noopener">GitHub Repository</a>.</p>
 
       <div class="footer-info">
-      <p>&copy; 2025 Dustin Whyte<br><span class="license-info">Released under the <a href="https://opensource.org/licenses/MIT" target="_blank" rel="noopener">MIT License</a></span></p>
+      <p>&copy; 2025–2026 Dustin Whyte<br><span class="license-info">Released under the <a href="https://opensource.org/licenses/MIT" target="_blank" rel="noopener">MIT License</a></span></p>
       <p class="license-description">This project is free software: you can redistribute it and/or modify it under the terms of the MIT License.</p>
       <div class="footer-links">
         <a href="#" data-popup-action="show-help">Help Guide</a>

--- a/src/html/privacy-policy.html
+++ b/src/html/privacy-policy.html
@@ -82,7 +82,7 @@
     </main>
 
     <footer class="privacy-footer">
-      <p>&copy; 2025 Dustin Whyte | <a href="../../index.html">Back to Wordmark</a></p>
+      <p>&copy; 2025–2026 Dustin Whyte | <a href="../../index.html">Back to Wordmark</a></p>
     </footer>
   </div>
 </body>

--- a/src/html/terms-of-service.html
+++ b/src/html/terms-of-service.html
@@ -89,7 +89,7 @@
     </main>
 
     <footer class="terms-footer">
-      <p>&copy; 2025 Dustin Whyte | <a href="../../index.html">Back to Wordmark</a></p>
+      <p>&copy; 2025–2026 Dustin Whyte | <a href="../../index.html">Back to Wordmark</a></p>
     </footer>
   </div>
 </body>


### PR DESCRIPTION
## Summary
The About panel and Help Guide had drifted out of date. This brings them in line with what the app actually ships.

- **Accurate tool list** — both panels previously listed only weather / OpenAI web search / MCP. Updated to the full set from `staticTools.ts`, with correct provider scoping: web search (OpenAI **or** xAI), weather (any provider), code interpreter (OpenAI/xAI), image generation (OpenAI image tool + xAI Grok Imagine generate/edit), file search (OpenAI), shell (OpenAI, off by default), and custom MCP servers.
- **Copyright year** — footer bumped `2025` → `2025–2026` across about, help, privacy, terms, contact.
- **GitHub links** — normalized `…/Wordmark` to the canonical lowercase `…/wordmark` slug.

## Verification
- `npm run validate` (html-validate) — clean
- Version number, provider list, and the privacy/terms/contact plumbing were already correct and left untouched.

🤖 Generated with [Claude Code](https://claude.com/claude-code)