### PR TITLE
Security fixes: escape untrusted values in innerHTML templates

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -19,6 +19,9 @@ jobs:
           node-version: ${{ matrix.node-version }}
           cache: npm
       - run: npm ci
+      - run: npm run typecheck
+      - run: npm run typecheck:tests
       - run: npm test
       - run: npm run lint
       - run: npm run validate
+      - run: npm run build

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "wordmark",
-  "version": "3.0.2",
+  "version": "3.0.3",
   "description": "Client-side AI assistant supporting OpenAI, xAI, and local LM Studio/Ollama servers.",
   "main": "index.html",
   "type": "module",

--- a/src/ts/components/attachments.ts
+++ b/src/ts/components/attachments.ts
@@ -6,6 +6,7 @@ import { state } from "../init/state.ts";
 import { showInfo } from "../utils/notifications.ts";
 import { filterSupportedFiles } from "../services/vectorStore.ts";
 import type { DirectoryFile } from "../../types/attachments.ts";
+import { escapeHtml } from "../utils/sanitize.ts";
 
 state.pendingUploads = [];
 state.pendingDocuments = [];
@@ -492,7 +493,7 @@ function showPendingUploadPreviews() {
       docInfo.className = "document-info";
       docInfo.innerHTML = `
         <span class="doc-icon">📁</span>
-        <span class="doc-name">${doc.directoryName}</span>
+        <span class="doc-name">${escapeHtml(doc.directoryName)}</span>
         <span class="doc-size">${directoryFiles.length} file${directoryFiles.length !== 1 ? "s" : ""} (${formatFileSize(totalSize)})</span>
       `;
 
@@ -515,7 +516,7 @@ function showPendingUploadPreviews() {
         const displayName = file.relativePath || file.name;
         fileItem.innerHTML = `
           <span class="file-item-icon">📄</span>
-          <span class="file-item-name">${displayName}</span>
+          <span class="file-item-name">${escapeHtml(displayName)}</span>
           <span class="file-item-size">${formatFileSize(file.size)}</span>
         `;
         fileList.appendChild(fileItem);
@@ -541,7 +542,7 @@ function showPendingUploadPreviews() {
       docInfo.className = "document-info";
       docInfo.innerHTML = `
         <span class="doc-icon">📄</span>
-        <span class="doc-name">${doc.name}</span>
+        <span class="doc-name">${escapeHtml(doc.name)}</span>
         <span class="doc-size">${formatFileSize(doc.size || 0)}</span>
       `;
 

--- a/src/ts/components/filesManager.ts
+++ b/src/ts/components/filesManager.ts
@@ -8,6 +8,7 @@
 import { showError, showInfo } from "../utils/notifications.ts";
 import { listAssistantFiles, deleteFile as deleteAssistantFile, deleteAllAssistantFiles } from "../services/files.ts";
 import { uploadFile as uploadAssistantFile } from "../services/vectorStore.ts";
+import { escapeHtml } from "../utils/sanitize.ts";
 
 /**
  * Initializes the Assistants file manager.
@@ -168,11 +169,3 @@ async function handleDeleteAllAssistantFiles() {
   }
 }
 
-/**
- * Escape HTML to prevent XSS
- */
-function escapeHtml(text: unknown) {
-  const div = document.createElement("div");
-  div.textContent = String(text ?? "");
-  return div.innerHTML;
-}

--- a/src/ts/components/logo.ts
+++ b/src/ts/components/logo.ts
@@ -37,9 +37,13 @@ function buildWordmarkLogo(svgContainer: Element | null) {
   svgContainer.appendChild(wPath);
 }
 
-/** Draws the animated wordmark logo into the header's SVG container. */
-export function renderWordmarkLogo() {
-  const svgContainer = document.querySelector("#wordmark-logo g");
+/**
+ * Draws the animated wordmark logo into an SVG `<g>` container.
+ *
+ * @param target - Container to draw into; defaults to the header logo's group.
+ */
+export function renderWordmarkLogo(target?: Element | null) {
+  const svgContainer = target ?? document.querySelector("#wordmark-logo g");
   if (!svgContainer) return;
 
   clearContainer(svgContainer);
@@ -53,5 +57,5 @@ export function renderWordmarkLogo() {
 }
 
 if (typeof document !== "undefined") {
-  document.addEventListener("DOMContentLoaded", renderWordmarkLogo);
+  document.addEventListener("DOMContentLoaded", () => renderWordmarkLogo());
 }

--- a/src/ts/components/ui/chatMessages.ts
+++ b/src/ts/components/ui/chatMessages.ts
@@ -21,19 +21,7 @@ function renderAssistantIcon(senderElement: HTMLElement) {
     </svg>
   `;
 
-  const originalSelector = document.querySelector;
-  document.querySelector = function(selector: string) {
-    if (selector === "#wordmark-logo g") {
-      return senderElement.querySelector("g");
-    }
-    return originalSelector.call(document, selector);
-  };
-
-  try {
-    renderWordmarkLogo();
-  } finally {
-    document.querySelector = originalSelector;
-  }
+  renderWordmarkLogo(senderElement.querySelector("g"));
 }
 
 /**
@@ -52,7 +40,7 @@ export function appendMessage(sender: string, content: string, type: string, ski
     messageElement.classList.add(type);
   }
 
-  const messageId = `msg-${Date.now()}`;
+  const messageId = generateMessageId();
   messageElement.id = messageId;
 
   const senderElement = document.createElement("div");

--- a/src/ts/components/ui/imageInteractions.ts
+++ b/src/ts/components/ui/imageInteractions.ts
@@ -10,6 +10,7 @@ import { state } from "../../init/state.ts";
 import { icon } from "../../utils/icons.ts";
 import { deleteImageFromDb } from "../../utils/imageStorage.ts";
 import { isMobileDevice } from "../../utils/mobileHandling.ts";
+import { escapeHtml } from "../../utils/sanitize.ts";
 import { detectMediaType, downloadMediaSource } from "../../services/mediaTools.ts";
 
 /** Normalized media descriptor consumed by the slideshow viewer. */
@@ -336,19 +337,14 @@ export function createImageSlideshow(images: any[], startIndex: number, isGaller
       ? `User uploaded ${item.mediaType} - no prompt available`
       : item.prompt;
 
-    const formattedPrompt = String(displayPrompt || "")
-      .replace(/&/g, "&amp;")
-      .replace(/</g, "&lt;")
-      .replace(/>/g, "&gt;")
-      .replace(/"/g, "&quot;")
-      .replace(/'/g, "&#x27;");
+    const formattedPrompt = escapeHtml(displayPrompt || "");
 
     infoPanel.innerHTML = `
       <h3>Media Details <span class="gallery-slideshow-counter">${currentIndex + 1} / ${images.length}</span></h3>
       <p><strong>${item.uploaded ? "Type:" : "Prompt:"}</strong><br><span class="prompt-text ${item.uploaded ? "uploaded-info" : ""}">${formattedPrompt || "No prompt available"}</span></p>
-      <p><strong>Media Type:</strong> ${item.mediaType}</p>
+      <p><strong>Media Type:</strong> ${escapeHtml(item.mediaType)}</p>
       <p><strong>Date:</strong> ${date}</p>
-      <p><strong>Filename:</strong> ${item.filename || "Unknown"}</p>
+      <p><strong>Filename:</strong> ${escapeHtml(item.filename || "Unknown")}</p>
     `;
   };
 

--- a/src/ts/components/vectorStoreManager.ts
+++ b/src/ts/components/vectorStoreManager.ts
@@ -7,6 +7,7 @@
  */
 
 import { showError, showInfo } from "../utils/notifications.ts";
+import { escapeHtml } from "../utils/sanitize.ts";
 import {
   listVectorStores,
   deleteVectorStore,
@@ -369,11 +370,3 @@ function formatBytes(bytes: number) {
   return Math.round(bytes / Math.pow(k, i) * 100) / 100 + " " + sizes[i];
 }
 
-/**
- * Escape HTML to prevent XSS
- */
-function escapeHtml(text: string) {
-  const div = document.createElement("div");
-  div.textContent = text;
-  return div.innerHTML;
-}

--- a/src/ts/init/eventListeners.ts
+++ b/src/ts/init/eventListeners.ts
@@ -63,7 +63,9 @@ export function setupEventListeners() {
     try {
       const enabled = getDataSettingsEnabled();
       dataSettingsToggle.checked = enabled;
-    } catch {}
+    } catch (e) {
+      console.warn("Failed to read data-settings preference:", e);
+    }
 
     dataSettingsToggle.addEventListener("change", (e) => {
       const on = (e.target as HTMLInputElement).checked;

--- a/src/ts/services/export.ts
+++ b/src/ts/services/export.ts
@@ -1,6 +1,7 @@
 import { elements, state } from "../init/state.ts";
 import { STORAGE_KEYS } from "../utils/storage.ts";
 import type { Message } from "../../types/api.ts";
+import { escapeHtml } from "../utils/sanitize.ts";
 /**
  * Chat export.
  *
@@ -194,19 +195,6 @@ function formatCsvValue(value: unknown) {
   const stringValue = value === null || value === undefined ? "" : String(value);
   const escaped = stringValue.replace(/"/g, "\"\"");
   return `"${escaped}"`;
-}
-
-/** Escapes HTML-special characters in a value for safe interpolation. */
-function escapeHtml(value: unknown) {
-  if (value === null || value === undefined) {
-    return "";
-  }
-  return String(value)
-    .replace(/&/g, "&amp;")
-    .replace(/</g, "&lt;")
-    .replace(/>/g, "&gt;")
-    .replace(/"/g, "&quot;")
-    .replace(/'/g, "&#39;");
 }
 
 /**

--- a/src/ts/services/history/list.ts
+++ b/src/ts/services/history/list.ts
@@ -14,6 +14,19 @@ import {
 import { DEFAULT_PERSONALITY } from "../../../config/config.ts";
 import { startNewConversation, loadConversation, renameConversation } from "./persistence.ts";
 
+/** Escapes HTML-special characters in a value for safe interpolation. */
+function escapeHtml(value: unknown) {
+  if (value === null || value === undefined) {
+    return "";
+  }
+  return String(value)
+    .replace(/&/g, "&amp;")
+    .replace(/</g, "&lt;")
+    .replace(/>/g, "&gt;")
+    .replace(/"/g, "&quot;")
+    .replace(/'/g, "&#39;");
+}
+
 /**
  * Renders the saved-conversation list into the history panel, wiring each
  * entry's load, rename, and delete actions.
@@ -292,15 +305,15 @@ export function renderChatHistoryList() {
 
         row.innerHTML = `
           <td class="col-title">
-            <div class="history-title">${title}</div>
+            <div class="history-title">${escapeHtml(title)}</div>
           </td>
           <td class="col-prompt">
-            <span class="prompt-type ${promptClass}">${promptInfo}</span>
+            <span class="prompt-type ${promptClass}">${escapeHtml(promptInfo)}</span>
           </td>
           <td class="col-model">
             <div class="model-info">
-              <div class="model-name">${modelInfo}</div>
-              <div class="service-name">${serviceInfo}</div>
+              <div class="model-name">${escapeHtml(modelInfo)}</div>
+              <div class="service-name">${escapeHtml(serviceInfo)}</div>
             </div>
           </td>
           <td class="col-stats">

--- a/src/ts/services/history/list.ts
+++ b/src/ts/services/history/list.ts
@@ -13,19 +13,7 @@ import {
 } from "../../utils/conversationStorage.ts";
 import { DEFAULT_PERSONALITY } from "../../../config/config.ts";
 import { startNewConversation, loadConversation, renameConversation } from "./persistence.ts";
-
-/** Escapes HTML-special characters in a value for safe interpolation. */
-function escapeHtml(value: unknown) {
-  if (value === null || value === undefined) {
-    return "";
-  }
-  return String(value)
-    .replace(/&/g, "&amp;")
-    .replace(/</g, "&lt;")
-    .replace(/>/g, "&gt;")
-    .replace(/"/g, "&quot;")
-    .replace(/'/g, "&#39;");
-}
+import { escapeHtml } from "../../utils/sanitize.ts";
 
 /**
  * Renders the saved-conversation list into the history panel, wiring each

--- a/src/ts/services/history/render.ts
+++ b/src/ts/services/history/render.ts
@@ -16,12 +16,13 @@ import { renderWordmarkLogo } from "../../components/logo.ts";
 import { setupImageInteractions } from "../../components/ui/imageInteractions.ts";
 import { updateHeaderInfo, updateModelSelector } from "../../components/settings.ts";
 import { config } from "../../../config/config.ts";
+import { escapeHtml } from "../../utils/sanitize.ts";
 import type { ConversationRecord, GeneratedImage } from "../../../types/common.ts";
 import type { Message } from "../../../types/api.ts";
 
 function createMissingMediaPlaceholder(filename: string, mediaType = "image") {
   const label = mediaType === "video" ? "Video" : "Image";
-  return `<div class='image-placeholder' style='padding:40px;background:#f1f1f1;border-radius:8px;margin:8px 0;text-align:center;font-style:italic;color:#666;'>${label} could not be loaded: ${filename}</div>`;
+  return `<div class='image-placeholder' style='padding:40px;background:#f1f1f1;border-radius:8px;margin:8px 0;text-align:center;font-style:italic;color:#666;'>${label} could not be loaded: ${escapeHtml(filename)}</div>`;
 }
 
 function findMediaRecord(convo: ConversationRecord, filename: string) {
@@ -114,7 +115,7 @@ function replaceImagePlaceholders(content: Message["content"], convo: Conversati
       state.imageDataCache.set(trimmed, src);
     }
 
-    return `<img src="${src}" alt="${img.prompt || "Generated Image"}" class="generated-image-thumbnail" data-media-type="image" data-filename="${trimmed}" data-prompt="${img.prompt || ""}" data-timestamp="${img.timestamp || ""}" style="max-width:160px;max-height:160px;border-radius:8px;margin:8px 0;cursor:pointer;" />`;
+    return `<img src="${escapeHtml(src)}" alt="${escapeHtml(img.prompt || "Generated Image")}" class="generated-image-thumbnail" data-media-type="image" data-filename="${escapeHtml(trimmed)}" data-prompt="${escapeHtml(img.prompt || "")}" data-timestamp="${escapeHtml(img.timestamp || "")}" style="max-width:160px;max-height:160px;border-radius:8px;margin:8px 0;cursor:pointer;" />`;
   });
 }
 
@@ -199,7 +200,7 @@ export function renderConversationMessages(convo: ConversationRecord, imageCache
     }
 
     displayContent = displayContent.replace(new RegExp("\\[\\[(?:MEDIA|IMAGE): ([^\\]]+)\\]\\]", "g"), (placeholder: string) => `
-      <span class="hidden-image-placeholder">${placeholder}</span>
+      <span class="hidden-image-placeholder">${escapeHtml(placeholder)}</span>
     `);
 
     if (imageFilenames.length > 0) {

--- a/src/ts/services/history/render.ts
+++ b/src/ts/services/history/render.ts
@@ -10,7 +10,7 @@ import { elements, state } from "../../init/state.ts";
 import { detectMediaType, getMediaDisplayUrl } from "../mediaTools.ts";
 import { updateMessageContent } from "../streaming/messageLifecycle.ts";
 import { updatePromptVisibility } from "../../components/ui/settingsControls.ts";
-import { highlightAndAddCopyButtons, addMessageCopyButton } from "../../components/messages.ts";
+import { highlightAndAddCopyButtons, addMessageCopyButton, generateMessageId } from "../../components/messages.ts";
 import { appendMessage } from "../../components/ui/chatMessages.ts";
 import { renderWordmarkLogo } from "../../components/logo.ts";
 import { setupImageInteractions } from "../../components/ui/imageInteractions.ts";
@@ -153,7 +153,7 @@ export function renderConversationMessages(convo: ConversationRecord, imageCache
 
     const messageElement = document.createElement("div");
     messageElement.classList.add("message", "assistant");
-    const messageId = msg.id || `msg-history-${Date.now()}`;
+    const messageId = msg.id || generateMessageId();
     messageElement.id = messageId;
 
     const sender = document.createElement("div");
@@ -164,19 +164,7 @@ export function renderConversationMessages(convo: ConversationRecord, imageCache
       </svg>
     `;
 
-    const originalSelector = document.querySelector;
-    document.querySelector = function(selector: string) {
-      if (selector === "#wordmark-logo g") {
-        return sender.querySelector("g");
-      }
-      return originalSelector.call(document, selector);
-    };
-
-    try {
-      renderWordmarkLogo();
-    } finally {
-      document.querySelector = originalSelector;
-    }
+    renderWordmarkLogo(sender.querySelector("g"));
 
     messageElement.appendChild(sender);
 

--- a/src/ts/services/mediaTools.ts
+++ b/src/ts/services/mediaTools.ts
@@ -7,6 +7,7 @@ import { loadImageFromDb, saveImageToDb } from "../utils/imageStorage.ts";
 import { toolImplementations } from "./toolImplementations.ts";
 import { getApiKey } from "./apiKeyStorage.ts";
 import { config } from "../../config/config.ts";
+import { escapeHtml } from "../utils/sanitize.ts";
 import type { GeneratedImage } from "../../types/common.ts";
 
 interface RegisterMediaOptions {
@@ -34,18 +35,6 @@ const XAI_IMAGE_ASPECT_RATIOS = [
   "3:2", "2:3", "2:1", "1:2",
   "19.5:9", "9:19.5", "20:9", "9:20", "auto",
 ];
-
-function escapeHtmlAttribute(value: unknown): string {
-  if (value === null || value === undefined) {
-    return "";
-  }
-  return String(value)
-    .replace(/&/g, "&amp;")
-    .replace(/"/g, "&quot;")
-    .replace(/'/g, "&#39;")
-    .replace(/</g, "&lt;")
-    .replace(/>/g, "&gt;");
-}
 
 /** Reports whether a MIME type is a video type. */
 export function isVideoMimeType(mimeType: string = ""): boolean {
@@ -107,11 +96,11 @@ function makeFilename(prefix: string, mimeType: string): string {
 /** Builds a sanitized `<video>` or `<img>` thumbnail element for a media record. */
 export function buildMediaRecordHtml(record: GeneratedImage): string {
   const mediaType = detectMediaType(record);
-  const safeFilename = escapeHtmlAttribute(record.filename || "");
-  const safePrompt = escapeHtmlAttribute(record.prompt || "");
-  const safeTimestamp = escapeHtmlAttribute(record.timestamp || "");
-  const safeAlt = escapeHtmlAttribute(record.prompt || (mediaType === "video" ? "Generated video" : "Generated image"));
-  const src = escapeHtmlAttribute(record.url || "");
+  const safeFilename = escapeHtml(record.filename || "");
+  const safePrompt = escapeHtml(record.prompt || "");
+  const safeTimestamp = escapeHtml(record.timestamp || "");
+  const safeAlt = escapeHtml(record.prompt || (mediaType === "video" ? "Generated video" : "Generated image"));
+  const src = escapeHtml(record.url || "");
 
   if (mediaType === "video") {
     return `<video src="${src}" class="generated-video-thumbnail" data-media-type="video" data-filename="${safeFilename}" data-prompt="${safePrompt}" data-timestamp="${safeTimestamp}" controls playsinline preload="metadata"></video>`;

--- a/src/ts/utils/memoryStorage.ts
+++ b/src/ts/utils/memoryStorage.ts
@@ -9,6 +9,15 @@ const MEMORY_ENABLED_KEY = STORAGE_KEYS.memoryEnabled;
 const MEMORY_LIMIT_KEY = STORAGE_KEYS.memoryLimit;
 const MEMORIES_KEY = STORAGE_KEYS.memories;
 
+/** Dispatches a memory event; tolerated to fail outside a browser (e.g. tests). */
+function emitMemoryEvent(name: string, detail: Record<string, unknown>) {
+  try {
+    window.dispatchEvent(new CustomEvent(name, { detail }));
+  } catch (e) {
+    console.warn(`Failed to dispatch ${name} event:`, e);
+  }
+}
+
 /** Seeds the enabled/limit/memories keys with defaults when absent. */
 function ensureMemoryDefaults() {
   if (localStorage.getItem(MEMORY_ENABLED_KEY) === null) {
@@ -34,7 +43,7 @@ export function getMemoryConfig() {
 /** Enables or disables the memory feature and emits a `memories:config` event. */
 export function setMemoryEnabled(enabled: boolean) {
   localStorage.setItem(MEMORY_ENABLED_KEY, enabled ? "true" : "false");
-  try { window.dispatchEvent(new CustomEvent("memories:config", { detail: { key: "enabled", value: Boolean(enabled) } })); } catch {}
+  emitMemoryEvent("memories:config", { key: "enabled", value: Boolean(enabled) });
 }
 
 /** Sets the maximum stored memories (≥ 1), trimming the oldest beyond the limit. */
@@ -45,9 +54,9 @@ export function setMemoryLimit(limit: string | number) {
   if (mems.length > newLimit) {
     const trimmed = mems.slice(-newLimit);
     writeJSON(MEMORIES_KEY, trimmed);
-    try { window.dispatchEvent(new CustomEvent("memories:changed", { detail: { type: "trim", count: trimmed.length } })); } catch {}
+    emitMemoryEvent("memories:changed", { type: "trim", count: trimmed.length });
   }
-  try { window.dispatchEvent(new CustomEvent("memories:config", { detail: { key: "limit", value: newLimit } })); } catch {}
+  emitMemoryEvent("memories:config", { key: "limit", value: newLimit });
 }
 
 /** Returns the stored memory strings, or `[]` if none/parse fails. */
@@ -77,14 +86,14 @@ export function addMemory(text: string) {
   mems.push(trimmed);
   const final = mems.length > limit ? mems.slice(-limit) : mems;
   writeJSON(MEMORIES_KEY, final);
-  try { window.dispatchEvent(new CustomEvent("memories:changed", { detail: { type: "add", value: trimmed } })); } catch {}
+  emitMemoryEvent("memories:changed", { type: "add", value: trimmed });
   return { ok: true, count: final.length };
 }
 
 /** Removes all stored memories and emits a `memories:changed` clear event. */
 export function clearAllMemories() {
   writeJSON(MEMORIES_KEY, []);
-  try { window.dispatchEvent(new CustomEvent("memories:changed", { detail: { type: "clear" } })); } catch {}
+  emitMemoryEvent("memories:changed", { type: "clear" });
   return { ok: true };
 }
 
@@ -98,7 +107,7 @@ export function removeMemoryAt(index: number) {
   if (index < 0 || index >= mems.length) return { ok: false, reason: "range" };
   mems.splice(index, 1);
   writeJSON(MEMORIES_KEY, mems);
-  try { window.dispatchEvent(new CustomEvent("memories:changed", { detail: { type: "remove", index } })); } catch {}
+  emitMemoryEvent("memories:changed", { type: "remove", index });
   return { ok: true, count: mems.length };
 }
 

--- a/src/ts/utils/sanitize.ts
+++ b/src/ts/utils/sanitize.ts
@@ -77,3 +77,16 @@ export function sanitizeWithMedia(html: string) {
 
   return tempDiv.innerHTML;
 }
+
+/** Escapes HTML-special characters in a value for safe interpolation into markup. */
+export function escapeHtml(value: unknown) {
+  if (value === null || value === undefined) {
+    return "";
+  }
+  return String(value)
+    .replace(/&/g, "&amp;")
+    .replace(/</g, "&lt;")
+    .replace(/>/g, "&gt;")
+    .replace(/"/g, "&quot;")
+    .replace(/'/g, "&#39;");
+}

--- a/tests/exportService.spec.ts
+++ b/tests/exportService.spec.ts
@@ -122,3 +122,63 @@ test('exportChat builds markdown export, dedupes reasoning, and triggers downloa
   assert.equal(reasoningMatches.length, 1);
   assert.ok(blobText.includes('Second thought'));
 });
+
+// Minimal document/URL stubs that capture the exported blob without a DOM.
+function setupExportCapture(format: string) {
+  globalThis.localStorage = createLocalStorage();
+  const capture: { blob: Blob | null } = { blob: null };
+  globalThis.document = {
+    body: { appendChild() {}, removeChild() {} },
+    getElementById() { return null; },
+    createElement() {
+      return { href: '', download: '', click() {} };
+    },
+  } as unknown as Document;
+  globalThis.URL = {
+    createObjectURL(blob: Blob) { capture.blob = blob; return 'blob:mock'; },
+    revokeObjectURL() {},
+  } as unknown as typeof URL;
+  globalThis.window = {} as Window & typeof globalThis;
+  elements.exportFormatSelector = { value: format } as unknown as HTMLSelectElement;
+  return capture;
+}
+
+test('exportChat escapes HTML-special message content in html exports', async () => {
+  const capture = setupExportCapture('html');
+  state.conversationHistory = [
+    {
+      role: 'user',
+      content: '<img src=x onerror=alert(1)>',
+      reasoning: [],
+      timestamp: '"><script>alert(2)</script>',
+    },
+  ] as unknown as typeof state.conversationHistory;
+
+  exportChat();
+
+  assert.ok(capture.blob);
+  const html = await (capture.blob as Blob).text();
+  assert.ok(!html.includes('<img src=x onerror=alert(1)>'));
+  assert.ok(!html.includes('<script>alert(2)</script>'));
+  assert.ok(html.includes('&lt;img src=x onerror=alert(1)&gt;'));
+  assert.ok(html.includes('&quot;&gt;&lt;script&gt;alert(2)&lt;/script&gt;'));
+});
+
+test('exportChat quotes and escapes CSV cells containing delimiters and quotes', async () => {
+  const capture = setupExportCapture('csv');
+  state.conversationHistory = [
+    {
+      role: 'user',
+      content: 'a,b "quoted"\nnew line',
+      reasoning: [],
+      timestamp: '2024-01-01T10:00:00Z',
+    },
+  ] as unknown as typeof state.conversationHistory;
+
+  exportChat();
+
+  assert.ok(capture.blob);
+  const csv = await (capture.blob as Blob).text();
+  assert.ok(csv.startsWith('"role","sender","content","reasoning","timestamp"'));
+  assert.ok(csv.includes('"a,b ""quoted""\nnew line"'));
+});

--- a/tests/sanitize.spec.ts
+++ b/tests/sanitize.spec.ts
@@ -1,0 +1,43 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+
+// sanitize.js imports DOMPurify, which probes for a window at import time;
+// give it an empty stub so the module loads under Node.
+globalThis.window = globalThis.window || ({} as Window & typeof globalThis);
+
+const { escapeHtml } = await import("../src/ts/utils/sanitize.ts");
+
+test("escapeHtml escapes all HTML-special characters", () => {
+  assert.equal(
+    escapeHtml("<script>alert(\"x\") & 'y'</script>"),
+    "&lt;script&gt;alert(&quot;x&quot;) &amp; &#39;y&#39;&lt;/script&gt;",
+  );
+});
+
+test("escapeHtml escapes quotes so values are safe in attribute contexts", () => {
+  const payload = "\" onmouseover=\"alert(1)";
+  const escaped = escapeHtml(payload);
+  assert.ok(!escaped.includes("\""));
+  assert.ok(!escaped.includes("'"));
+  assert.equal(escaped, "&quot; onmouseover=&quot;alert(1)");
+});
+
+test("escapeHtml escapes ampersands first and does not double-escape input", () => {
+  assert.equal(escapeHtml("&lt;"), "&amp;lt;");
+  assert.equal(escapeHtml("a & b"), "a &amp; b");
+});
+
+test("escapeHtml returns empty string for null and undefined", () => {
+  assert.equal(escapeHtml(null), "");
+  assert.equal(escapeHtml(undefined), "");
+});
+
+test("escapeHtml stringifies non-string values", () => {
+  assert.equal(escapeHtml(42), "42");
+  assert.equal(escapeHtml(false), "false");
+  assert.equal(escapeHtml(0), "0");
+});
+
+test("escapeHtml leaves plain text untouched", () => {
+  assert.equal(escapeHtml("Hello, world! 123 _-+=[]"), "Hello, world! 123 _-+=[]");
+});


### PR DESCRIPTION
## Summary
- Fix stored XSS by escaping conversation fields in the history list and media attributes in history render
- Escape untrusted values in all remaining innerHTML templates, sharing a single `escapeHtml` helper
- Add tests for `escapeHtml` and export escaping behavior
- Remove the `document.querySelector` monkey-patch, fix ID collisions, and log previously swallowed errors
- Add typecheck and build steps to CI

🤖 Generated with [Claude Code](https://claude.com/claude-code)